### PR TITLE
RMET-971 Health and Fitness Plugin - Fix android request permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-09-13
+- Fixed RequestPermissions for Android (https://outsystemsrd.atlassian.net/browse/RMET-971)
+
 ## 2021-09-10
 - Added code to check for google play services (https://outsystemsrd.atlassian.net/browse/RMET-830)
 

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -14,9 +14,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.fitness.Fitness
 import com.google.android.gms.fitness.FitnessOptions
-import com.google.android.gms.fitness.data.DataSource
-import com.google.android.gms.fitness.data.DataType
-import com.google.android.gms.fitness.data.Field
+import com.google.android.gms.fitness.data.*
 import com.google.android.gms.fitness.request.DataReadRequest
 import com.google.android.gms.fitness.request.DataUpdateListenerRegistrationRequest
 import com.google.android.gms.fitness.request.SensorRequest
@@ -110,7 +108,7 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
             if(summaryVariablesPermissions.isActive){
                 appendPermissions(summaryVariablesPermissions, permissionList, EnumVariableGroup.SUMMARY)
             }
-            parseCustomPermissions(customPermissions, permissionList)
+            permissionList.addAll(parseCustomPermissions(customPermissions, permissionList))
         }
         initFitnessOptions(permissionList)
     }
@@ -194,7 +192,9 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
     }
 
     private fun getVariableByName(name : String) : GoogleFitVariable? {
-        return if(healthVariablesMap.containsKey(name)){
+        return if(fitnessVariablesMap.containsKey(name)){
+            fitnessVariablesMap[name]
+        } else if(healthVariablesMap.containsKey(name)){
             healthVariablesMap[name]
         } else if(profileVariablesMap.containsKey(name)){
             profileVariablesMap[name]
@@ -216,13 +216,18 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     fun requestGoogleFitPermissions() {
-        fitnessOptions?.let {
-            GoogleSignIn.requestPermissions(
-                platformInterface.getActivity(),  // your activity
-                OSHealthFitness.GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,  // e.g. 1
-                account,
-                it
-            )
+        if(!checkAllGoogleFitPermissionGranted()){
+            fitnessOptions?.let {
+                GoogleSignIn.requestPermissions(
+                    platformInterface.getActivity(),  // your activity
+                    OSHealthFitness.GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,  // e.g. 1
+                    account,
+                    it
+                )
+            }
+        }
+        else{
+            platformInterface.sendPluginResult("success")
         }
     }
 

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -225,6 +225,8 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
                     it
                 )
             }
+            //we should also call sendPluginResult in the onActivityResult after the user provides the permissions in the permission dialog
+            //but the onActivityResult is not being called for some reason
         }
         else{
             platformInterface.sendPluginResult("success")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes a small bug we had on the requestPermissions for Android. We were not using the custom permissions in the request for GoogleSignIn.

Also added a verification so that we only ask for GoogleSignIn permissions when necessary.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-971


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally with Android 11 device. Also tested MABS 7.1 build and everything is working fine.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
