### PR TITLE
RMET-976 Health & Fitness Plugin - WriteProfileData android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-09-15
+- Implemented WriteProfileData for Android (https://outsystemsrd.atlassian.net/browse/RMET-976)
+
 ## 2021-09-13
 - Fixed RequestPermissions for Android (https://outsystemsrd.atlassian.net/browse/RMET-971)
 

--- a/src/android/com/outsystems/plugins/healthfitness/HealthFitnessError.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/HealthFitnessError.kt
@@ -3,6 +3,8 @@ package com.outsystems.plugins.healthfitness
 enum class HealthFitnessError(val code: Int, val message: String) {
 
     GOOGLE_SERVICES_ERROR_RESOLVABLE (100, "Google Play Services error user resolvable"),
-    GOOGLE_SERVICES_ERROR (101, "Google Play Services error");
-
+    GOOGLE_SERVICES_ERROR (101, "Google Play Services error"),
+    WRITE_VALUE_INCORRECT_FORMAT_ERROR(102, "Value provided is not in correct format"),
+    WRITE_VALUE_OUT_OF_RANGE_ERROR(103, "Value provided is out of range for this variable"),
+    WRITE_DATA_ERROR(104, "Error while writing data")
 }

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -8,8 +8,6 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.fitness.FitnessOptions
-import com.google.android.gms.fitness.data.*
 import com.outsystems.plugins.healthfitness.store.HealthStore
 
 import org.apache.cordova.*
@@ -52,6 +50,9 @@ class OSHealthFitness : CordovaImplementation() {
             "getData" -> {
                 getData(args)
             }
+            "writeData" -> {
+                writeData(args)
+            }
         }
         return true
     }
@@ -78,7 +79,7 @@ class OSHealthFitness : CordovaImplementation() {
     }
 
     private fun checkAllGoogleFitPermissionGranted(): Boolean {
-       return healthStore!!.checkAllGoogleFitPermissionGranted()
+        return healthStore!!.checkAllGoogleFitPermissionGranted()
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -100,10 +101,14 @@ class OSHealthFitness : CordovaImplementation() {
         return false
     }
 
-    //Get steps by day
     @RequiresApi(api = Build.VERSION_CODES.O)
     private fun getData(args : JSONArray) {
         healthStore?.getData(args)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun writeData(args: JSONArray) {
+        healthStore?.updateData(args)
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -108,7 +108,12 @@ class OSHealthFitness : CordovaImplementation() {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun writeData(args: JSONArray) {
-        healthStore?.updateData(args)
+
+        //process parameters
+        val variable = args.getString(0)
+        val value = args.getString(1)
+
+        healthStore?.updateData(variable, value)
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)

--- a/src/android/com/outsystems/plugins/healthfitness/store/GoogleFitVariable.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/GoogleFitVariable.kt
@@ -1,5 +1,9 @@
 package com.outsystems.plugins.healthfitness.store
 
 import com.google.android.gms.fitness.data.DataType
+import com.google.android.gms.fitness.data.Field
 
-data class GoogleFitVariable (val dataType : DataType)
+data class GoogleFitVariable (
+    val dataType : DataType,
+    val fields : List<Field>
+)

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -21,6 +21,7 @@ import com.google.android.gms.fitness.request.SensorRequest
 import com.google.android.gms.fitness.result.DataReadResponse
 import com.google.gson.Gson
 import com.outsystems.plugins.healthfitness.AndroidPlatformInterface
+import com.outsystems.plugins.healthfitness.HealthFitnessError
 import com.outsystems.plugins.healthfitness.OSHealthFitness
 import com.outsystems.plugins.healthfitness.MyDataUpdateService
 import org.json.JSONArray
@@ -228,7 +229,7 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
             //but the onActivityResult is not being called for some reason
         }
         else{
-            platformInterface.sendPluginResult("success")
+            platformInterface.sendPluginResult("success", null)
         }
     }
 
@@ -259,7 +260,6 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
         //process parameters
         val variable = args.getString(0)
         val value = args.getString(1).toFloat()
-
 
         val dataType = profileVariablesMap[variable]?.dataType
 
@@ -293,13 +293,15 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
             .addOnSuccessListener {
                 updatedField = true
                 Log.i("Access GoogleFit:", "DataSet updated successfully!")
-                //MANDAR sendPluginResult de sucesso
+                platformInterface.sendPluginResult("success", null)
             }
             .addOnFailureListener { e ->
                 Log.w("Access GoogleFit:", "There was an error updating the DataSet", e)
-                Log.w("Access GoogleFit:", e.message.toString())
-                Log.w("Access GoogleFit:", e.localizedMessage.toString())
-                //MANDAR sendPluginResult de erro
+                //In this case, what is the error we want to send in the callback?
+                //We could identify the exception that is thrown and send an error accordingly?
+                //Maybe catch that com.google.android.gms.common.api.ApiException: 4: The user must be signed in to make this API call.
+                //For now we will send a generic error message
+                platformInterface.sendPluginResult(null, Pair(HealthFitnessError.WRITE_DATA_ERROR.code, HealthFitnessError.WRITE_DATA_ERROR.message))
             }
     }
 

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -227,8 +227,9 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
                     it
                 )
             }
-            //we should also call sendPluginResult in the onActivityResult after the user provides the permissions in the permission dialog
+            //instead of calling sendPluginResult here we should call it in the onActivityResult after the user provides the permissions in the permission dialog
             //but the onActivityResult is not being called for some reason
+            platformInterface.sendPluginResult("success", null)
         }
         else{
             platformInterface.sendPluginResult("success", null)

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -64,7 +64,9 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
     private val profileVariablesMap: Map<String, GoogleFitVariable> by lazy {
         mapOf(
             "HEIGHT" to GoogleFitVariable(DataType.TYPE_HEIGHT, listOf(Field.FIELD_HEIGHT)),
-            "WEIGHT" to GoogleFitVariable(DataType.TYPE_WEIGHT, listOf(Field.FIELD_WEIGHT))
+            "WEIGHT" to GoogleFitVariable(DataType.TYPE_WEIGHT, listOf(Field.FIELD_WEIGHT)),
+            "BODY_FAT_PERCENTAGE" to GoogleFitVariable(DataType.TYPE_BODY_FAT_PERCENTAGE, listOf(Field.FIELD_PERCENTAGE)),
+            "BASAL_METABOLIC_RATE" to GoogleFitVariable(DataType.TYPE_BASAL_METABOLIC_RATE, listOf(Field.FIELD_CALORIES))
         )
     }
     private val summaryVariablesMap: Map<String, GoogleFitVariable> by lazy {

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -261,6 +261,7 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
 
         //process parameters
         val variable = args.getString(0)
+        //right now we are only writing data which are float values
         val value = args.getString(1).toFloat()
 
         val dataType = profileVariablesMap[variable]?.dataType
@@ -285,15 +286,12 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
             .add(valueToWrite)
             .build()
 
-        var updatedField: Boolean? = null
-
         Fitness.getHistoryClient(
             activity,
             account
         )
             .insertData(dataSet)
             .addOnSuccessListener {
-                updatedField = true
                 Log.i("Access GoogleFit:", "DataSet updated successfully!")
                 platformInterface.sendPluginResult("success", null)
             }

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -258,12 +258,10 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    fun updateData(args: JSONArray) {
+    fun updateData(variable: String, value: String) {
 
-        //process parameters
-        val variable = args.getString(0)
         //right now we are only writing data which are float values
-        val value = args.getString(1).toFloat()
+        val convertedValue = value.toFloat()
 
         val dataType = profileVariablesMap[variable]?.dataType
 
@@ -280,7 +278,7 @@ class  HealthStore(val platformInterface: AndroidPlatformInterface) {
         val timestamp = System.currentTimeMillis()
         val valueToWrite = DataPoint.builder(dataSourceWrite)
             .setTimestamp(timestamp, TimeUnit.MILLISECONDS)
-            .setField(fieldType, value)
+            .setField(fieldType, convertedValue)
             .build()
 
         val dataSet = DataSet.builder(dataSourceWrite)

--- a/www/OSHealthFitness.js
+++ b/www/OSHealthFitness.js
@@ -27,3 +27,7 @@ exports.updateData = function (success, error) {
 exports.enableBackgroundJob = function (success, error) {
     exec(success, error, 'OSHealthFitness', 'enableBackgroundJob');
 };
+
+exports.writeData = function (variable, value, success, error) {
+    exec(success, error, 'OSHealthFitness', 'writeData', [variable,value]);
+};

--- a/www/OSHealthFitness.js
+++ b/www/OSHealthFitness.js
@@ -28,6 +28,6 @@ exports.enableBackgroundJob = function (success, error) {
     exec(success, error, 'OSHealthFitness', 'enableBackgroundJob');
 };
 
-exports.writeData = function (variable, value, success, error) {
-    exec(success, error, 'OSHealthFitness', 'writeData', [variable,value]);
+exports.writeData = function (success, error, variable, value) {
+    exec(success, error, 'OSHealthFitness', 'writeData', [variable, value]);
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds implementation for WriteProfileData method in Android. As of now, all the profile variables we use can be passed as Float, so we use the DataPoint.builder.setField method for Float values (useful for Height and Weight).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-976


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally in an Android 11 device. Was able to Write data for all the 4 profile variables. MABS 7.1 build also working.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
