### PR TITLE
RMET-996 Health & Fitness Plugin - Fix android permissions callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
-## 2021-09-15
+## 2021-09-21
+- Fixed requestPermissions callback for Android (https://outsystemsrd.atlassian.net/browse/RMET-996)
+
+## 2021-09-21
 - Using getLastSignedInAccount for Android (https://outsystemsrd.atlassian.net/browse/RMET-1022)
 
 ## 2021-09-15

--- a/src/android/com/outsystems/plugins/healthfitness/AndroidPlatformInterface.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/AndroidPlatformInterface.kt
@@ -9,7 +9,6 @@ interface AndroidPlatformInterface {
 
     fun getContext(): Context
     fun getActivity(): Activity
-    fun setAsActivityResultCallback()
 
     fun onRequestPermissionResult(
         requestCode: Int,

--- a/src/android/com/outsystems/plugins/healthfitness/AndroidPlatformInterface.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/AndroidPlatformInterface.kt
@@ -9,8 +9,13 @@ interface AndroidPlatformInterface {
 
     fun getContext(): Context
     fun getActivity(): Activity
-    fun onRequestPermissionResult( requestCode: Int, permissions: Array<String>,
-                            grantResults: IntArray)
+    fun setAsActivityResultCallback()
+
+    fun onRequestPermissionResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray)
+
     fun <T> sendPluginResult(resultVariable: T, error: Pair<Int, String>? = null)
     fun areGooglePlayServicesAvailable(callbackContext: CallbackContext): Boolean
 

--- a/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
@@ -27,7 +27,7 @@ abstract  class CordovaImplementation : CordovaPlugin(), AndroidPlatformInterfac
     override fun getActivity(): Activity {
         return cordova.activity
     }
-    override fun setAsActivityResultCallback() {
+    fun setAsActivityResultCallback() {
         cordova.setActivityResultCallback(this)
     }
 

--- a/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
@@ -20,27 +20,25 @@ abstract  class CordovaImplementation : CordovaPlugin(), AndroidPlatformInterfac
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
         super.initialize(cordova, webView)
+    }
+    override fun getContext(): Context {
+        return cordova.context
+    }
+    override fun getActivity(): Activity {
+        return cordova.activity
+    }
+    override fun setAsActivityResultCallback() {
         cordova.setActivityResultCallback(this)
     }
 
-     override fun getContext(): Context {
-        return cordova.context
-    }
-
-     override fun getActivity(): Activity {
-        return cordova.activity
-    }
-
-     fun onPermissionResult(
+    fun onPermissionResult(
         requestCode: Int, permissions: Array<String>,
-        grantResults: IntArray
-    ) {
+        grantResults: IntArray) {
         super.onRequestPermissionResult(requestCode,permissions,grantResults)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int,
-                                  intent: Intent
-    ) {
+                                  intent: Intent) {
         super.onActivityResult(requestCode,resultCode,intent)
     }
 

--- a/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
@@ -20,6 +20,7 @@ abstract  class CordovaImplementation : CordovaPlugin(), AndroidPlatformInterfac
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
         super.initialize(cordova, webView)
+        cordova.setActivityResultCallback(this)
     }
 
      override fun getContext(): Context {

--- a/src/android/com/outsystems/plugins/healthfitness/HealthFitnessError.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/HealthFitnessError.kt
@@ -7,5 +7,6 @@ enum class HealthFitnessError(val code: Int, val message: String) {
     WRITE_VALUE_INCORRECT_FORMAT_ERROR(102, "Value provided is not in correct format"),
     WRITE_VALUE_OUT_OF_RANGE_ERROR(103, "Value provided is out of range for this variable"),
     WRITE_DATA_ERROR(104, "Error while writing data"),
-    READ_DATA_ERROR(105, "Error while reading data")
+    READ_DATA_ERROR(105, "Error while reading data"),
+    PERMISSIONS_NOT_GRANTED_ERROR(106, "Permissions were not granted")
 }

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -68,6 +68,7 @@ class OSHealthFitness : CordovaImplementation() {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun initAndRequestPermissions(args : JSONArray) {
+        setAsActivityResultCallback()
         healthStore?.initAndRequestPermissions(args)
         checkAndGrantPermissions()
     }

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -118,7 +118,7 @@ class OSHealthFitness : CordovaImplementation() {
 
         //process parameters
         val variable = args.getString(0)
-        val value = args.getString(1)
+        val value = args.getDouble(1).toFloat()
 
         healthStore?.updateData(variable, value)
     }

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -1,6 +1,7 @@
 package com.outsystems.plugins.healthfitness
 
 import android.Manifest
+import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -134,9 +135,16 @@ class OSHealthFitness : CordovaImplementation() {
     @RequiresApi(api = Build.VERSION_CODES.O)
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent) {
         super.onActivityResult(requestCode, resultCode, intent)
-        when (requestCode) {
-            GOOGLE_FIT_PERMISSIONS_REQUEST_CODE -> {
-
+        when (resultCode) {
+            Activity.RESULT_OK -> when (requestCode) {
+                GOOGLE_FIT_PERMISSIONS_REQUEST_CODE -> sendPluginResult("success", null)
+                else -> {
+                    // Result wasn't from Google Fit
+                }
+            }
+            else -> {
+                // Permission not granted
+                sendPluginResult(null, Pair(HealthFitnessError.PERMISSIONS_NOT_GRANTED_ERROR.code, HealthFitnessError.PERMISSIONS_NOT_GRANTED_ERROR.message))
             }
         }
     }

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -347,10 +347,9 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
-    fun updateData(variable: String, value: String) {
+    fun updateData(variable: String, value: Float) {
 
         //right now we are only writing data which are float values
-        val convertedValue = value.toFloat()
 
         val dataType = profileVariablesMap[variable]?.dataType
 
@@ -367,7 +366,7 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
         val timestamp = System.currentTimeMillis()
         val valueToWrite = DataPoint.builder(dataSourceWrite)
                 .setTimestamp(timestamp, TimeUnit.MILLISECONDS)
-                .setField(fieldType, convertedValue)
+                .setField(fieldType, value)
                 .build()
 
         val dataSet = DataSet.builder(dataSourceWrite)

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -309,6 +309,7 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
     fun requestGoogleFitPermissions() {
         if(!checkAllGoogleFitPermissionGranted()){
             fitnessOptions?.let {
+                platformInterface.setAsActivityResultCallback()
                 GoogleSignIn.requestPermissions(
                     platformInterface.getActivity(),  // your activity
                     OSHealthFitness.GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,  // e.g. 1

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -316,9 +316,6 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
                     it
                 )
             }
-            //instead of calling sendPluginResult here we should call it in the onActivityResult after the user provides the permissions in the permission dialog
-            //but the onActivityResult is not being called for some reason
-            platformInterface.sendPluginResult("success", null)
         }
         else{
             platformInterface.sendPluginResult("success", null)

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -87,7 +87,7 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
                 Field.FIELD_CALORIES
             )),
             "PUSH_COUNT" to GoogleFitVariable(DataType.TYPE_ACTIVITY_SEGMENT, listOf(
-                //TODO:
+                //TODO: different from iOS
             )),
             "MOVE_MINUTES" to GoogleFitVariable(DataType.TYPE_MOVE_MINUTES, listOf(
                 Field.FIELD_DURATION
@@ -113,7 +113,7 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
                 Field.FIELD_VOLUME
             )),
             "NUTRITION" to GoogleFitVariable(DataType.TYPE_NUTRITION, listOf(
-                //TODO:
+                //TODO: different from iOS
             ))
         )
     }
@@ -542,6 +542,10 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
                 }
                 .addOnFailureListener { dataReadResponse: Exception ->
                     Log.d("STORE", dataReadResponse.message!!)
+                    platformInterface.sendPluginResult(
+                        null,
+                        Pair(HealthFitnessError.READ_DATA_ERROR.code, HealthFitnessError.READ_DATA_ERROR.message)
+                    )
                 }
         }
     }

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -309,7 +309,6 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
     fun requestGoogleFitPermissions() {
         if(!checkAllGoogleFitPermissionGranted()){
             fitnessOptions?.let {
-                platformInterface.setAsActivityResultCallback()
                 GoogleSignIn.requestPermissions(
                     platformInterface.getActivity(),  // your activity
                     OSHealthFitness.GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,  // e.g. 1


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes requestPermissions callback to be handled by onActivityResult.

Also changes value received by writeData to be a float instead of a String.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-996


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally in an Android 11 device. Tested case when we cancel the permissions, and the case where we accept the permissions. MABS 7.1 build also working.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
