### PR TITLE
Android 8 requirement remove

### DIFF
--- a/src/android/com/outsystems/plugins/healthfitness/AndroidPlatformInterface.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/AndroidPlatformInterface.kt
@@ -2,7 +2,6 @@ package com.outsystems.plugins.healthfitness
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import org.apache.cordova.CallbackContext
 
 interface AndroidPlatformInterface {

--- a/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/CordovaImplementation.kt
@@ -3,7 +3,6 @@ package com.outsystems.plugins.healthfitness
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import com.google.android.gms.fitness.data.DataType
 import org.apache.cordova.*
 import org.json.JSONArray
 import org.json.JSONObject

--- a/src/android/com/outsystems/plugins/healthfitness/MyDataUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/MyDataUpdateService.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
 
 
 class MyDataUpdateService : IntentService("MyDataUpdateService") {
-    @RequiresApi(Build.VERSION_CODES.O)
+
     override fun onHandleIntent(intent: Intent?) {
         val update = DataUpdateNotification.getDataUpdateNotification(intent)
         // Show the time interval over which the data points were collected.

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -4,17 +4,13 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.gson.Gson
 import com.outsystems.plugins.healthfitness.store.AdvancedQueryParameters
 import com.outsystems.plugins.healthfitness.store.HealthStore
-
 import org.apache.cordova.*
-
 import org.json.JSONArray
 
 
@@ -35,7 +31,7 @@ class OSHealthFitness : CordovaImplementation() {
         healthStore = HealthStore(this)
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
+
     override fun execute(
         action: String,
         args: JSONArray,
@@ -66,7 +62,7 @@ class OSHealthFitness : CordovaImplementation() {
 
     //create array of permission oauth
 
-    @RequiresApi(Build.VERSION_CODES.O)
+
     private fun initAndRequestPermissions(args : JSONArray) {
 
         val customPermissions = args.getString(0)
@@ -100,7 +96,6 @@ class OSHealthFitness : CordovaImplementation() {
     }
 
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     private fun checkAndGrantPermissions(){
         val permissions = arrayOf(
             Manifest.permission.ACTIVITY_RECOGNITION,
@@ -123,13 +118,11 @@ class OSHealthFitness : CordovaImplementation() {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     private fun advancedQuery(args : JSONArray) {
         val parameters = gson.fromJson(args.getString(0), AdvancedQueryParameters::class.java)
         healthStore?.advancedQuery(parameters)
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     private fun writeData(args: JSONArray) {
 
         //process parameters
@@ -139,7 +132,6 @@ class OSHealthFitness : CordovaImplementation() {
         healthStore?.updateData(variable, value)
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     private fun getLastRecord(args: JSONArray) {
 
         //process parameters
@@ -147,7 +139,6 @@ class OSHealthFitness : CordovaImplementation() {
         healthStore?.getLastRecord(variable)
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent) {
         //super.onActivityResult(requestCode, resultCode, intent)
         when (resultCode) {
@@ -182,7 +173,6 @@ class OSHealthFitness : CordovaImplementation() {
         return true
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     override fun onRequestPermissionResult(
         requestCode: Int,
         permissions: Array<String>,

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -4,9 +4,13 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.Api
 import com.google.gson.Gson
 import com.outsystems.plugins.healthfitness.store.AdvancedQueryParameters
 import com.outsystems.plugins.healthfitness.store.HealthStore
@@ -82,26 +86,24 @@ class OSHealthFitness : CordovaImplementation() {
         checkAndGrantPermissions()
     }
 
-    private fun areAndroidPermissionsGranted(permissions: Array<String>): Boolean {
+    private fun areAndroidPermissionsGranted(permissions: List<String>): Boolean {
         permissions.forEach {
-            if (ContextCompat.checkSelfPermission(
-                    cordova.activity,
-                    it
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
+            if (ContextCompat.checkSelfPermission(cordova.activity, it) != PackageManager.PERMISSION_GRANTED) {
                 return false
             }
         }
         return true
     }
 
-
     private fun checkAndGrantPermissions(){
-        val permissions = arrayOf(
-            Manifest.permission.ACTIVITY_RECOGNITION,
+        val permissions = mutableListOf(
             Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.BODY_SENSORS
         )
+
+        if(SDK_INT >= Build.VERSION_CODES.Q) {
+            permissions.add(Manifest.permission.ACTIVITY_RECOGNITION)
+        }
 
         if (areAndroidPermissionsGranted(permissions)) {
             if(!healthStore!!.areGoogleFitPermissionsGranted()){
@@ -113,7 +115,7 @@ class OSHealthFitness : CordovaImplementation() {
             PermissionHelper.requestPermissions(
                 this,
                 ACTIVITY_LOCATION_PERMISSIONS_REQUEST_CODE,
-                permissions
+                permissions.toTypedArray()
             )
         }
     }

--- a/src/android/com/outsystems/plugins/healthfitness/store/AdvancedQuery.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/AdvancedQuery.kt
@@ -1,17 +1,11 @@
 package com.outsystems.plugins.healthfitness.store
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.google.android.gms.fitness.data.Bucket
 import com.google.android.gms.fitness.data.DataPoint
 import com.google.android.gms.fitness.data.DataSource
 import com.google.android.gms.fitness.data.DataType
 import com.google.android.gms.fitness.request.DataReadRequest
 import java.text.SimpleDateFormat
-import java.time.Instant
-import java.time.Month
-import java.time.ZoneId
-import java.time.temporal.WeekFields
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -255,7 +249,7 @@ class AdvancedQuery(
 
     private class WeekBucketProcessor(val timeUnitLength : Int, queryStartDate : Long, queryEndDate : Long) :
         BucketProcessor(queryStartDate, queryEndDate) {
-        @RequiresApi(Build.VERSION_CODES.O)
+
         override fun process(buckets: List<Bucket>): List<ProcessedBucket> {
 
             val format = SimpleDateFormat("yyyy.MM.dd HH:mm")
@@ -271,14 +265,14 @@ class AdvancedQuery(
 
                 dataPointsPerBucket.forEach { dataPoint ->
 
-                    val dataPointDate = Instant
-                        .ofEpochMilli(dataPoint.getStartTime(TimeUnit.MILLISECONDS))
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDate()
+                    val dataPointDate = Date(dataPoint.getStartTime(TimeUnit.MILLISECONDS))
+                    val isoCalendar = Calendar.getInstance()
+                    isoCalendar.time = dataPointDate
+                    isoCalendar.minimalDaysInFirstWeek = 4;
+                    isoCalendar.firstDayOfWeek = Calendar.MONDAY;
 
-                    val weekFields: WeekFields = WeekFields.ISO
-                    val weekNumber = dataPointDate.get(weekFields.weekOfWeekBasedYear())
-                    val yearNumber = dataPointDate.year
+                    val weekNumber = isoCalendar.get(Calendar.WEEK_OF_YEAR);
+                    val yearNumber = isoCalendar.get(Calendar.YEAR);
                     val dataPointKey = "$weekNumber$yearNumber"
 
                     if(!processedBuckets.containsKey(dataPointKey)) {
@@ -320,7 +314,10 @@ class AdvancedQuery(
             while(!weekKeyQueue.isEmpty()) {
                 val keyAnchor = weekKeyQueue.pop()
 
-                for(i in 1 until Integer.min(timeUnitLength, weekKeyQueue.size + 1)) {
+                var limit = weekKeyQueue.size + 1
+                if(timeUnitLength < limit){ limit = timeUnitLength }
+
+                for(i in 1 until limit) {
 
                     val keyToMergeWithAnchor = weekKeyQueue.pop()
                     val valuesToMerge = processedBuckets[keyToMergeWithAnchor]!!
@@ -339,7 +336,7 @@ class AdvancedQuery(
 
     private class MonthBucketProcessor(val timeUnitLength : Int, queryStartDate : Long, queryEndDate : Long) :
         BucketProcessor(queryStartDate, queryEndDate) {
-        @RequiresApi(Build.VERSION_CODES.O)
+
         override fun process(buckets: List<Bucket>): List<ProcessedBucket> {
             val format = SimpleDateFormat("yyyy.MM.dd HH:mm")
             val processedBuckets : MutableMap<String, ProcessedBucket> = mutableMapOf()
@@ -353,13 +350,12 @@ class AdvancedQuery(
 
                 dataPointsPerBucket.forEach { dataPoint ->
 
-                    val dataPointDate = Instant
-                        .ofEpochMilli(dataPoint.getStartTime(TimeUnit.MILLISECONDS))
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDate()
+                    val dataPointDate = Date(dataPoint.getStartTime(TimeUnit.MILLISECONDS))
+                    val calendar = Calendar.getInstance()
+                    calendar.time = dataPointDate
 
-                    val monthNumber = dataPointDate.monthValue
-                    val yearNumber = dataPointDate.year
+                    val monthNumber = calendar.get(Calendar.MONTH)
+                    val yearNumber = calendar.get(Calendar.YEAR)
                     val dataPointKey = "$monthNumber$yearNumber"
 
                     if(!processedBuckets.containsKey(dataPointKey)) {
@@ -401,7 +397,10 @@ class AdvancedQuery(
             while(!bucketKeyQueue.isEmpty()) {
                 val keyAnchor = bucketKeyQueue.pop()
 
-                for(i in 1 until Integer.min(timeUnitLength, bucketKeyQueue.size + 1)) {
+                var limit = bucketKeyQueue.size + 1
+                if(timeUnitLength < limit){ limit = timeUnitLength }
+
+                for(i in 1 until limit) {
 
                     val keyToMergeWithAnchor = bucketKeyQueue.pop()
                     val valuesToMerge = processedBuckets[keyToMergeWithAnchor]!!
@@ -419,7 +418,7 @@ class AdvancedQuery(
 
     private class YearBucketProcessor(val timeUnitLength : Int, queryStartDate : Long, queryEndDate : Long) :
         BucketProcessor(queryStartDate, queryEndDate) {
-        @RequiresApi(Build.VERSION_CODES.O)
+
         override fun process(buckets: List<Bucket>): List<ProcessedBucket> {
             val format = SimpleDateFormat("yyyy.MM.dd HH:mm")
             val processedBuckets : MutableMap<String, ProcessedBucket> = mutableMapOf()
@@ -433,12 +432,11 @@ class AdvancedQuery(
 
                 dataPointsPerBucket.forEach { dataPoint ->
 
-                    val dataPointDate = Instant
-                        .ofEpochMilli(dataPoint.getStartTime(TimeUnit.MILLISECONDS))
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDate()
+                    val dataPointDate = Date(dataPoint.getStartTime(TimeUnit.MILLISECONDS))
+                    val calendar = Calendar.getInstance()
+                    calendar.time = dataPointDate
 
-                    val yearNumber = dataPointDate.year
+                    val yearNumber = calendar.get(Calendar.YEAR)
                     val dataPointKey = "$yearNumber"
 
                     if(!processedBuckets.containsKey(dataPointKey)) {
@@ -476,7 +474,10 @@ class AdvancedQuery(
             while(!bucketKeyQueue.isEmpty()) {
                 val keyAnchor = bucketKeyQueue.pop()
 
-                for(i in 1 until Integer.min(timeUnitLength, bucketKeyQueue.size + 1)) {
+                var limit = bucketKeyQueue.size + 1
+                if(timeUnitLength < limit){ limit = timeUnitLength }
+
+                for(i in 1 until limit) {
 
                     val keyToMergeWithAnchor = bucketKeyQueue.pop()
                     val valuesToMerge = processedBuckets[keyToMergeWithAnchor]!!

--- a/src/android/com/outsystems/plugins/healthfitness/store/AdvancedQueryResponseBlock.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/AdvancedQueryResponseBlock.kt
@@ -1,7 +1,5 @@
 package com.outsystems.plugins.healthfitness.store
 
-import java.util.*
-
 data class AdvancedQueryResponseBlock (
     val block : Int,
     val startDate : Long,

--- a/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/store/HealthStore.kt
@@ -2,24 +2,21 @@ package com.outsystems.plugins.healthfitness.store
 
 import android.app.Activity
 import android.content.Context
-import android.os.Build
 import android.util.Log
-import androidx.annotation.RequiresApi
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.fitness.Fitness
 import com.google.android.gms.fitness.FitnessOptions
 import com.google.android.gms.fitness.data.*
-import com.google.android.gms.fitness.result.DataReadResponse
-import com.google.gson.Gson
-import java.text.SimpleDateFormat
-import java.time.Instant
-import java.util.*
-import com.outsystems.plugins.healthfitness.HealthFitnessError
 import com.google.android.gms.fitness.data.DataPoint
 import com.google.android.gms.fitness.data.DataSet
+import com.google.android.gms.fitness.result.DataReadResponse
+import com.google.gson.Gson
 import com.outsystems.plugins.healthfitness.AndroidPlatformInterface
+import com.outsystems.plugins.healthfitness.HealthFitnessError
 import com.outsystems.plugins.healthfitness.OSHealthFitness
+import java.text.SimpleDateFormat
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 
@@ -217,7 +214,6 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     fun initAndRequestPermissions(
         customPermissions: String,
         allVariables: String,
@@ -364,7 +360,6 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
         return fitnessBuild.build()
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     fun requestGoogleFitPermissions() {
         if(areGoogleFitPermissionsGranted(account, fitnessOptions)){
             platformInterface.sendPluginResult("success")
@@ -393,7 +388,6 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     fun updateData(variableName: String, value: Float) {
 
         //right now we are only writing data which are float values
@@ -454,7 +448,6 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
                 }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     fun getLastRecord(variable: String) {
 
         val endDate: Long = Date().time
@@ -463,14 +456,13 @@ class HealthStore(val platformInterface: AndroidPlatformInterface) {
 
         val advancedQueryParameters = AdvancedQueryParameters(
             variable,
-            Date.from(Instant.ofEpochMilli(startDate)),
-            Date.from(Instant.ofEpochMilli(endDate)),
+            Date(startDate),
+            Date(endDate),
             limit = 1
         )
         advancedQuery(advancedQueryParameters)
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     fun advancedQuery(parameters : AdvancedQueryParameters) {
 
         val variable = getVariableByName(parameters.variable)


### PR DESCRIPTION
## Description
Removed references to Kotlin Instant. Using Calendar instead.
ACTIVITY_RECOGNITION is only requested on Android 10 or higher.
Also took the opportunity to optimize imports.

## Context
Android code continuously made use of "RequiresApi" annotation. The reason behind this was that the code used a few features to convert date, time and milliseconds. This was not the optimal, since MABS supports older versions than Android 8.
Furthermore, Manifest.permission.ACTIVITY_RECOGNITION is only available on Android 10 or higher. This was cause the app to never ask for GooglePermissions because this Android Permissions was never granted on lower version devices.

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript

## Tests
Tested on Device Android 11, and Emulator Android 9.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
