### PR TITLE
Fixed bug in request permissions

### DIFF
--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -75,14 +75,20 @@ class OSHealthFitness : CordovaImplementation() {
         val profileVariables = args.getString(4)
         val summaryVariables = args.getString(5)
 
-        healthStore?.initAndRequestPermissions(
-            customPermissions,
-            allVariables,
-            fitnessVariables,
-            healthVariables,
-            profileVariables,
-            summaryVariables)
-        checkAndGrantPermissions()
+        try {
+            healthStore?.initAndRequestPermissions(
+                customPermissions,
+                allVariables,
+                fitnessVariables,
+                healthVariables,
+                profileVariables,
+                summaryVariables)
+            checkAndGrantPermissions()
+        }
+        catch (hse : HealthStoreException) {
+            sendPluginResult(null, Pair(hse.error.code, hse.error.message))
+        }
+
     }
 
     private fun areAndroidPermissionsGranted(permissions: List<String>): Boolean {


### PR DESCRIPTION
## Description
A small fix on InitPermissions.

## Context
We changed the way our HealthStore uses the android interface. In this case we are no longer using this interface directly. Now, if there's an error, an exception is thrown and we are able to abstract the interface from the HealthStore.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on device

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
