### PR TITLE
RMET-1240 H&F Plugin - Implement Notification Frequency (waiting period) on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+- Implementation of notificaiton frequency (waiting period) for Android (https://outsystemsrd.atlassian.net/browse/RMET-1240)
+
+## [Version 1.0.2]
 
 ## 2021-11-18
 - Implementation of new variables and new version of background job iOS (https://outsystemsrd.atlassian.net/browse/RMET-1138)

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/BackgroundJobParameters.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/BackgroundJobParameters.kt
@@ -9,7 +9,8 @@ data class BackgroundJobParameters (
     @SerializedName("TimeUnit") val timeUnit : String? = null,
     @SerializedName("TimeUnitGrouping") val timeUnitGrouping : Int? = 1,
     @SerializedName("JobFrequency") val jobFrequency : String? = null,
-    @SerializedName("WaitingPeriod") val waitingPeriod : Int? = 10,
+    @SerializedName("NotificationFrequency") val notificationFrequency : String? = null,
+    @SerializedName("NotificationFrequencyGrouping") val notificationFrequencyGrouping : Int? = 1,
     @SerializedName("NotificationHeader") val notificationHeader : String,
     @SerializedName("NotificationBody") val notificationBody : String
 )

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/BackgroundJobParameters.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/BackgroundJobParameters.kt
@@ -9,6 +9,7 @@ data class BackgroundJobParameters (
     @SerializedName("TimeUnit") val timeUnit : String? = null,
     @SerializedName("TimeUnitGrouping") val timeUnitGrouping : Int? = 1,
     @SerializedName("JobFrequency") val jobFrequency : String? = null,
+    @SerializedName("WaitingPeriod") val waitingPeriod : Int? = 10,
     @SerializedName("NotificationHeader") val notificationHeader : String,
     @SerializedName("NotificationBody") val notificationBody : String
 )

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -66,11 +66,41 @@ class VariableUpdateService : BroadcastReceiver() {
             //notificationFrequencyGrouping = 1
             //waitingPeriod = 1 day = 24*60*60*1000 millis
 
+
+            //currentTime = 9 dezembro
+            //lastNotification = 6 dezembro
+            //waitingPeriod = 3 day
+            //notificationFrequency * grouping = 1 day
+            // 9 - 6 >= 3 (1)
+
             //check waiting period, only do query after checking that
             val currentTime = System.currentTimeMillis()
-            if(currentTime - job.lastNotificationTimestamp >= (job.waitingPeriod)){
+            if(currentTime - job.lastNotificationTimestamp!! >= (job.waitingPeriod!!)){
 
-                job.lastNotificationTimestamp = currentTime
+                if(job.notificationFrequency in listOf("HOUR", "DAY", "WEEK", "MONTH", "YEAR")){
+                    val calendar = Calendar.getInstance()
+                    calendar.set(Calendar.MINUTE, 0)
+                    calendar.set(Calendar.SECOND, 0)
+                    if(job.notificationFrequency == "DAY"){
+                        calendar.set(Calendar.HOUR, 0)
+                    }
+                    else if(job.notificationFrequency == "MONTH"){
+                        calendar.set(Calendar.DAY_OF_MONTH, 1)
+                        calendar.set(Calendar.HOUR, 0)
+                    }
+                    else if (job.notificationFrequency == "YEAR"){
+                        calendar.set(Calendar.MONTH, 1)
+                        calendar.set(Calendar.DAY_OF_MONTH, 1)
+                        calendar.set(Calendar.HOUR, 0)
+                    }
+
+                    job.lastNotificationTimestamp = calendar.timeInMillis
+
+                }
+                else{
+                    job.lastNotificationTimestamp = currentTime
+                }
+
                 database.updateBackgroundJob(job)
 
                 job.notificationId?.let { notificationId ->

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -7,7 +7,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.outsystems.plugins.healthfitnesslib.background.database.BackgroundJob
@@ -17,7 +16,6 @@ import com.outsystems.plugins.healthfitnesslib.store.HealthStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import java.text.SimpleDateFormat
 import java.util.*
 
 class VariableUpdateService : BroadcastReceiver() {

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -67,7 +67,11 @@ class VariableUpdateService : BroadcastReceiver() {
             //waitingPeriod = 1 day = 24*60*60*1000 millis
 
             //check waiting period, only do query after checking that
-            if(System.currentTimeMillis() - job.lastNotificationTimestamp!! >= (job.waitingPeriod!!)){
+            val currentTime = System.currentTimeMillis()
+            if(currentTime - job.lastNotificationTimestamp >= (job.waitingPeriod)){
+
+                job.lastNotificationTimestamp = currentTime
+                database.updateBackgroundJob(job)
 
                 job.notificationId?.let { notificationId ->
                     db.fetchNotification(notificationId)?.let { notification ->

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -55,6 +55,9 @@ class VariableUpdateService : BroadcastReceiver() {
 
         backgroundJobs?.forEach { job ->
 
+            val nf = job.notificationFrequency
+            val nfg = job.notificationFrequencyGrouping
+
             //notificationFrequency = SECOND
             //notificationFrequencyGrouping = 30
             //waitingPeriod = 30 seconds = 30*1000 millis

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -55,8 +55,16 @@ class VariableUpdateService : BroadcastReceiver() {
 
         backgroundJobs?.forEach { job ->
 
+            //notificationFrequency = SECOND
+            //notificationFrequencyGrouping = 30
+            //waitingPeriod = 30 seconds = 30*1000 millis
+
+            //notificationFrequency = DAY
+            //notificationFrequencyGrouping = 1
+            //waitingPeriod = 1 day = 24*60*60*1000 millis
+
             //check waiting period, only do query after checking that
-            if(System.currentTimeMillis() - job.lastNotificationTimestamp!! >= (job.waitingPeriod!!*1000)){
+            if(System.currentTimeMillis() - job.lastNotificationTimestamp!! >= (job.waitingPeriod!!)){
 
                 job.notificationId?.let { notificationId ->
                     db.fetchNotification(notificationId)?.let { notification ->

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -58,44 +58,39 @@ class VariableUpdateService : BroadcastReceiver() {
             val currentTimestamp = System.currentTimeMillis()
             val nextNotificationTimestamp = job.nextNotificationTimestamp
 
-            if(currentTimestamp >= nextNotificationTimestamp) {
+            if(currentTimestamp >= nextNotificationTimestamp || job.notificationFrequency == "ALWAYS") {
 
                 val nextNotificationCalendar = Calendar.getInstance()
                 nextNotificationCalendar.timeInMillis = currentTimestamp
                 nextNotificationCalendar.minimalDaysInFirstWeek = 4
                 nextNotificationCalendar.firstDayOfWeek = Calendar.MONDAY
 
-                val format = SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS")
-                Log.d("NEXT_NOTIF", format.format(nextNotificationCalendar.timeInMillis))
-
                 if(job.notificationFrequency == "SECOND") {
-                    nextNotificationCalendar.add(Calendar.SECOND, 1)
+                    nextNotificationCalendar.add(Calendar.SECOND, job.notificationFrequencyGrouping)
                 }
                 else if(job.notificationFrequency == "MINUTE") {
-                    nextNotificationCalendar.add(Calendar.MINUTE, 1)
+                    nextNotificationCalendar.add(Calendar.MINUTE, job.notificationFrequencyGrouping)
                 }
                 else if(job.notificationFrequency == "HOUR") {
-                    nextNotificationCalendar.add(Calendar.HOUR, 1)
+                    nextNotificationCalendar.add(Calendar.HOUR, job.notificationFrequencyGrouping)
+                    nextNotificationCalendar.startOfUnit(Calendar.HOUR)
                 }
                 else if(job.notificationFrequency == "DAY") {
-                    nextNotificationCalendar.add(Calendar.DATE, 1)
+                    nextNotificationCalendar.add(Calendar.DATE, job.notificationFrequencyGrouping)
                     nextNotificationCalendar.startOfUnit(Calendar.DATE)
                 }
                 else if(job.notificationFrequency == "WEEK") {
-                    nextNotificationCalendar.add(Calendar.WEEK_OF_MONTH, 1)
+                    nextNotificationCalendar.add(Calendar.WEEK_OF_MONTH, job.notificationFrequencyGrouping)
                     nextNotificationCalendar.startOfUnit(Calendar.WEEK_OF_MONTH)
                 }
                 else if(job.notificationFrequency == "MONTH") {
-                    nextNotificationCalendar.add(Calendar.MONTH, 1)
+                    nextNotificationCalendar.add(Calendar.MONTH, job.notificationFrequencyGrouping)
                     nextNotificationCalendar.startOfUnit(Calendar.MONTH)
                 }
                 else if (job.notificationFrequency == "YEAR") {
-                    nextNotificationCalendar.add(Calendar.YEAR, 1)
+                    nextNotificationCalendar.add(Calendar.YEAR, job.notificationFrequencyGrouping)
                     nextNotificationCalendar.startOfUnit(Calendar.YEAR)
                 }
-
-                val debugDate = format.format(nextNotificationCalendar.timeInMillis)
-                Log.d("NEXT_NOTIF", debugDate)
 
                 job.nextNotificationTimestamp = nextNotificationCalendar.timeInMillis
 
@@ -196,26 +191,29 @@ class VariableUpdateService : BroadcastReceiver() {
     private fun Calendar.startOfUnit(unit: Int): Calendar {
         var unitVal = 0
         when(unit){
-            Calendar.DATE -> unitVal = 1
-            Calendar.WEEK_OF_MONTH -> unitVal = 2
-            Calendar.MONTH -> unitVal = 3
-            Calendar.YEAR -> unitVal = 4
+            Calendar.HOUR -> unitVal = 1
+            Calendar.DATE -> unitVal = 2
+            Calendar.WEEK_OF_MONTH -> unitVal = 3
+            Calendar.MONTH -> unitVal = 4
+            Calendar.YEAR -> unitVal = 5
         }
 
-        if(unitVal >= 4){
-            this.set(Calendar.MONTH, 1)
+        if(unitVal >= 5){
+            this.set(Calendar.MONTH, 0)
         }
-        if(unitVal >= 3){
+        if(unitVal >= 4){
             this.set(Calendar.DAY_OF_MONTH, 1)
         }
-        if(unitVal >= 2){
+        if(unitVal == 3){
             this.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+        }
+        if(unitVal >= 2){
+            this.set(Calendar.HOUR_OF_DAY, 0)
         }
         if(unitVal >= 1){
             this.set(Calendar.MILLISECOND, 0)
             this.set(Calendar.SECOND, 0)
             this.set(Calendar.MINUTE, 0)
-            this.set(Calendar.HOUR_OF_DAY, 0)
         }
 
         return this

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/AppDatabase.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/AppDatabase.kt
@@ -2,9 +2,40 @@ package com.outsystems.plugins.healthfitnesslib.background.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.room.migration.Migration
 
-@Database(entities = [BackgroundJob::class, Notification::class], version = 1)
+@Database(
+    entities = [BackgroundJob::class, Notification::class],
+    version = 2
+)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun backgroundJobDao(): BackgroundJobDao
     abstract fun notificationDao(): NotificationDao
+
+    companion object {
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
+                            "ADD COLUMN notification_frequency TEXT NOT NULL DEFAULT 'ALWAYS'")
+                database.execSQL(
+                    "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
+                            "ADD COLUMN notification_frequency_grouping INTEGER NOT NULL DEFAULT 1")
+                database.execSQL(
+                    "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
+                            "ADD COLUMN waiting_period INTEGER NOT NULL DEFAULT 0")
+                database.execSQL(
+                    "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
+                            "ADD COLUMN last_notification_timestamp INTEGER NOT NULL DEFAULT 0")
+
+                database.execSQL(
+                    "UPDATE ${BackgroundJob.TABLE_NAME} " +
+                            "SET notification_frequency = 'ALWAYS', " +
+                            "notification_frequency_grouping = 1, " +
+                            "waiting_period = 0, " +
+                            "last_notification_timestamp = 0")
+            }
+        }
+    }
 }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/AppDatabase.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/AppDatabase.kt
@@ -24,10 +24,7 @@ abstract class AppDatabase : RoomDatabase() {
                             "ADD COLUMN notification_frequency_grouping INTEGER NOT NULL DEFAULT 1")
                 database.execSQL(
                     "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
-                            "ADD COLUMN waiting_period INTEGER NOT NULL DEFAULT 0")
-                database.execSQL(
-                    "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
-                            "ADD COLUMN last_notification_timestamp INTEGER NOT NULL DEFAULT 0")
+                            "ADD COLUMN next_notification_timestamp INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/AppDatabase.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/AppDatabase.kt
@@ -28,13 +28,6 @@ abstract class AppDatabase : RoomDatabase() {
                 database.execSQL(
                     "ALTER TABLE ${BackgroundJob.TABLE_NAME} " +
                             "ADD COLUMN last_notification_timestamp INTEGER NOT NULL DEFAULT 0")
-
-                database.execSQL(
-                    "UPDATE ${BackgroundJob.TABLE_NAME} " +
-                            "SET notification_frequency = 'ALWAYS', " +
-                            "notification_frequency_grouping = 1, " +
-                            "waiting_period = 0, " +
-                            "last_notification_timestamp = 0")
             }
         }
     }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
@@ -28,7 +28,6 @@ open class BackgroundJob {
     @ColumnInfo(name = "time_unit") var timeUnit: String? = null
     @ColumnInfo(name = "time_unit_grouping") var timeUnitGrouping: Int? = null
     @ColumnInfo(name = "notification_id") var notificationId: Long? = null
-
     @ColumnInfo(name = "notification_frequency") var notificationFrequency: String = "ALWAYS"
     @ColumnInfo(name = "notification_frequency_grouping") var notificationFrequencyGrouping: Int = 1
     @ColumnInfo(name = "waiting_period") var waitingPeriod: Int = 0
@@ -38,8 +37,3 @@ open class BackgroundJob {
         const val TABLE_NAME: String= "backgroundJob"
     }
 }
-
-
-
-
-

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 
 @Entity(
+    tableName = BackgroundJob.TABLE_NAME,
     primaryKeys = ["variable", "comparison", "value"],
     foreignKeys = [ForeignKey(
         entity = Notification::class,
@@ -27,11 +28,15 @@ open class BackgroundJob {
     @ColumnInfo(name = "time_unit") var timeUnit: String? = null
     @ColumnInfo(name = "time_unit_grouping") var timeUnitGrouping: Int? = null
     @ColumnInfo(name = "notification_id") var notificationId: Long? = null
-    @ColumnInfo(name = "notification_frequency") var notificationFrequency: String? = null
-    @ColumnInfo(name = "notification_frequency_grouping") var notificationFrequencyGrouping: Int? = null
-    @ColumnInfo(name = "waiting_period") var waitingPeriod: Int? = null
-    @ColumnInfo(name = "last_notification_timestamp") var lastNotificationTimestamp: Long? = 0
 
+    @ColumnInfo(name = "notification_frequency") var notificationFrequency: String = "ALWAYS"
+    @ColumnInfo(name = "notification_frequency_grouping") var notificationFrequencyGrouping: Int = 1
+    @ColumnInfo(name = "waiting_period") var waitingPeriod: Int = 0
+    @ColumnInfo(name = "last_notification_timestamp") var lastNotificationTimestamp: Long = 0
+
+    companion object {
+        const val TABLE_NAME: String= "backgroundJob"
+    }
 }
 
 

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
@@ -30,8 +30,7 @@ open class BackgroundJob {
     @ColumnInfo(name = "notification_id") var notificationId: Long? = null
     @ColumnInfo(name = "notification_frequency") var notificationFrequency: String = "ALWAYS"
     @ColumnInfo(name = "notification_frequency_grouping") var notificationFrequencyGrouping: Int = 1
-    @ColumnInfo(name = "waiting_period") var waitingPeriod: Int = 0
-    @ColumnInfo(name = "last_notification_timestamp") var lastNotificationTimestamp: Long = 0
+    @ColumnInfo(name = "next_notification_timestamp") var nextNotificationTimestamp: Long = 0
 
     companion object {
         const val TABLE_NAME: String= "backgroundJob"

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
@@ -27,7 +27,9 @@ open class BackgroundJob {
     @ColumnInfo(name = "time_unit") var timeUnit: String? = null
     @ColumnInfo(name = "time_unit_grouping") var timeUnitGrouping: Int? = null
     @ColumnInfo(name = "notification_id") var notificationId: Long? = null
-    @ColumnInfo(name = "waiting_period") var waitingPeriod: Int? = 10
+    @ColumnInfo(name = "notification_frequency") var notificationFrequency: String? = null
+    @ColumnInfo(name = "notification_frequency_grouping") var notificationFrequencyGrouping: Int? = null
+    @ColumnInfo(name = "waiting_period") var waitingPeriod: Int? = null
     @ColumnInfo(name = "last_notification_timestamp") var lastNotificationTimestamp: Long? = 0
 
 }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJob.kt
@@ -27,6 +27,9 @@ open class BackgroundJob {
     @ColumnInfo(name = "time_unit") var timeUnit: String? = null
     @ColumnInfo(name = "time_unit_grouping") var timeUnitGrouping: Int? = null
     @ColumnInfo(name = "notification_id") var notificationId: Long? = null
+    @ColumnInfo(name = "waiting_period") var waitingPeriod: Int? = 10
+    @ColumnInfo(name = "last_notification_timestamp") var lastNotificationTimestamp: Long? = 0
+
 }
 
 

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJobDao.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJobDao.kt
@@ -1,9 +1,6 @@
 package com.outsystems.plugins.healthfitnesslib.background.database
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.Query
+import androidx.room.*
 
 @Dao
 interface BackgroundJobDao {
@@ -22,5 +19,8 @@ interface BackgroundJobDao {
 
     @Delete
     fun delete(backgroundJob: BackgroundJob)
+
+    @Update
+    fun update(backgroundJob: BackgroundJob)
 
 }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJobDao.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/BackgroundJobDao.kt
@@ -8,13 +8,13 @@ import androidx.room.Query
 @Dao
 interface BackgroundJobDao {
 
-    @Query("SELECT * FROM backgroundJob")
+    @Query("SELECT * FROM ${BackgroundJob.TABLE_NAME}")
     fun getAll(): List<BackgroundJob>
 
     //@Query("SELECT * FROM backgroundJob WHERE variable = :variable AND comparison = :comparison AND value = :value")
     //fun findByPrimaryKey(variable: String, comparison: String, value: Float)
 
-    @Query("SELECT * FROM backgroundJob WHERE variable = :name")
+    @Query("SELECT * FROM ${BackgroundJob.TABLE_NAME} WHERE variable = :name")
     fun findByVariableName(name : String): List<BackgroundJob>
 
     @Insert

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/DatabaseManager.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/DatabaseManager.kt
@@ -68,6 +68,10 @@ class DatabaseManager(context : Context) : DatabaseManagerInterface {
         backgroundJobDao?.delete(backgroundJob)
     }
 
+    override fun updateBackgroundJob(backgroundJob: BackgroundJob) {
+        backgroundJobDao?.update(backgroundJob)
+    }
+
     override fun runInTransaction(closude : () -> Unit){
         database?.runInTransaction(Runnable {
             closude()

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/DatabaseManager.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/DatabaseManager.kt
@@ -18,8 +18,9 @@ class DatabaseManager(context : Context) : DatabaseManagerInterface {
             // Should we close the database instance? If so, when.
             database = Room.databaseBuilder(
                 context.applicationContext,
-                AppDatabase::class.java, "database-name"
-            ).build()
+                AppDatabase::class.java, "database-name")
+                .addMigrations(AppDatabase.MIGRATION_1_2)
+                .build()
 
             backgroundJobDao = database!!.backgroundJobDao()
             notificationDao = database!!.notificationDao()

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/DatabaseManagerInterface.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/DatabaseManagerInterface.kt
@@ -7,5 +7,6 @@ interface DatabaseManagerInterface {
     fun fetchBackgroundJobs(variable : String) : List<BackgroundJob>?
     fun fetchNotification(id : Long) : Notification?
     fun deleteBackgroundJob(backgroundJob : BackgroundJob)
+    fun updateBackgroundJob(backgroundJob: BackgroundJob)
     fun runInTransaction(closude : () -> Unit)
 }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/Notification.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/Notification.kt
@@ -24,4 +24,7 @@ class Notification{
         return random.nextInt()
     }
 
+    companion object {
+        const val TABLE_NAME: String= "notification"
+    }
 }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/NotificationDao.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/database/NotificationDao.kt
@@ -8,10 +8,10 @@ import androidx.room.Query
 @Dao
 interface NotificationDao {
 
-    @Query("SELECT * FROM notification")
+    @Query("SELECT * FROM ${Notification.TABLE_NAME}")
     fun getAll(): List<Notification>
 
-    @Query("SELECT * FROM notification WHERE id = :id")
+    @Query("SELECT * FROM ${Notification.TABLE_NAME} WHERE id = :id")
     fun findById(id : Long): List<Notification>
 
     @Insert

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -669,7 +669,7 @@ class HealthStore(
                     launch(Dispatchers.IO) {
 
                         try {
-                            database.runInTransaction({
+                            database.runInTransaction {
                                 val nNotification = database.fetchNotifications()
                                 val notification = Notification().apply {
                                     this.title = parameters.notificationHeader
@@ -686,25 +686,36 @@ class HealthStore(
                                     this.timeUnit = parameters.timeUnit
                                     this.timeUnitGrouping = parameters.timeUnitGrouping
 
-                                    this.notificationFrequency = parameters.notificationFrequency.toString()
-                                    this.notificationFrequencyGrouping = parameters.notificationFrequencyGrouping!!
+                                    this.notificationFrequency =
+                                        parameters.notificationFrequency.toString()
+                                    this.notificationFrequencyGrouping =
+                                        parameters.notificationFrequencyGrouping!!
 
                                     when (parameters.notificationFrequency) {
-                                        "SECOND" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*1000
-                                        "MINUTE" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*60*1000
-                                        "HOUR" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*60*60*1000
-                                        "DAY" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*24*60*60*1000
-                                        "WEEK" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*7*24*60*60*1000
-                                        "MONTH" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*30*24*60*60*1000
-                                        "YEAR" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*12*30*24*60*60*1000
+                                        "SECOND" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 1000
+                                        "MINUTE" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 60 * 1000
+                                        "HOUR" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 60 * 60 * 1000
+                                        "DAY" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 24 * 60 * 60 * 1000
+                                        "WEEK" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 7 * 24 * 60 * 60 * 1000
+                                        "MONTH" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 30 * 24 * 60 * 60 * 1000
+                                        "YEAR" -> this.waitingPeriod =
+                                            parameters.notificationFrequencyGrouping * 12 * 30 * 24 * 60 * 60 * 1000
                                         else -> {
-                                            this.waitingPeriod = 0 //we don't want a waiting period in this case
+                                            this.waitingPeriod =
+                                                0 //we don't want a waiting period in this case
                                         }
                                     }
-                                    this.lastNotificationTimestamp = System.currentTimeMillis() - this.waitingPeriod!!
+                                    this.lastNotificationTimestamp =
+                                        System.currentTimeMillis() - this.waitingPeriod!!
                                 }
                                 database.insert(backgroundJob)
-                            })
+                            }
                             onSuccess("success")
                         } catch(sqle : SQLiteException) {
                             onError(HealthFitnessError.BACKGROUND_JOB_ALREADY_EXISTS_ERROR)

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -670,7 +670,7 @@ class HealthStore(
 
                         try {
                             database.runInTransaction {
-                                val nNotification = database.fetchNotifications()
+
                                 val notification = Notification().apply {
                                     this.title = parameters.notificationHeader
                                     this.body = parameters.notificationBody
@@ -700,60 +700,9 @@ class HealthStore(
                                     val second = calendar.get(Calendar.SECOND)
                                     calendar.set(year, month, day, hour, minute, second)
 
-                                    when (parameters.notificationFrequency) {
-                                        "SECOND" -> {
-                                            //this.waitingPeriod =
-                                                    //parameters.notificationFrequencyGrouping * 1000
-                                            this.waitingPeriod = parameters.notificationFrequencyGrouping * 1000
-                                            this.lastNotificationTimestamp = System.currentTimeMillis() - this.waitingPeriod!!
-                                            //calendar.add(Calendar.SECOND, -(notificationFrequencyGrouping))
-                                        }
-                                        "MINUTE" -> {
-                                            //this.waitingPeriod =
-                                                //parameters.notificationFrequencyGrouping * 60 * 1000
-                                            this.waitingPeriod = parameters.notificationFrequencyGrouping * 60 * 1000
-                                            this.lastNotificationTimestamp = System.currentTimeMillis() - this.waitingPeriod!!
-                                            //calendar.add(Calendar.MINUTE, -(notificationFrequencyGrouping))
-                                        }
-                                        "HOUR" -> {
-                                            //this.waitingPeriod =
-                                                //parameters.notificationFrequencyGrouping * 60 * 60 * 1000
-                                            TimeUnit.HOURS.toMillis(parameters.notificationFrequencyGrouping as Long)
-                                            calendar.add(Calendar.HOUR, -(notificationFrequencyGrouping))
-                                            this.lastNotificationTimestamp = calendar.timeInMillis
-                                        }
-                                        "DAY" -> {
-                                            //this.waitingPeriod =
-                                                //parameters.notificationFrequencyGrouping * 24 * 60 * 60 * 1000
-                                            calendar.add(Calendar.DAY_OF_MONTH, -(notificationFrequencyGrouping))
-                                            this.lastNotificationTimestamp = calendar.timeInMillis
-                                        }
-                                        "WEEK" -> {
-                                            this.waitingPeriod =
-                                                parameters.notificationFrequencyGrouping * 7 * 24 * 60 * 60 * 1000
-                                            calendar.add(Calendar.WEEK_OF_MONTH, -(notificationFrequencyGrouping))
-                                            this.lastNotificationTimestamp = calendar.timeInMillis
-                                        }
-                                        "MONTH" -> {
-                                            this.waitingPeriod =
-                                                parameters.notificationFrequencyGrouping * 30 * 24 * 60 * 60 * 1000
-                                            calendar.add(Calendar.MONTH, -(notificationFrequencyGrouping))
-                                            this.lastNotificationTimestamp = calendar.timeInMillis
-                                        }
-                                        "YEAR" -> {
-                                            this.waitingPeriod =
-                                                parameters.notificationFrequencyGrouping * 12 * 30 * 24 * 60 * 60 * 1000
-                                            calendar.add(Calendar.YEAR, -(notificationFrequencyGrouping))
-                                            this.lastNotificationTimestamp = calendar.timeInMillis
-                                        }
-                                        else -> {
-                                            //this.waitingPeriod =
-                                                //0 //we don't want a waiting period in this case
-                                        }
-                                    }
-                                    //this.lastNotificationTimestamp = calendar.timeInMillis
-                                    //this.lastNotificationTimestamp =
-                                        //System.currentTimeMillis() - this.waitingPeriod!!
+                                    val timeNow = System.currentTimeMillis()
+                                    this.nextNotificationTimestamp = timeNow
+
                                 }
                                 database.insert(backgroundJob)
                             }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -690,16 +690,7 @@ class HealthStore(
                                         parameters.notificationFrequency.toString()
                                     this.notificationFrequencyGrouping =
                                         parameters.notificationFrequencyGrouping!!
-
-                                    val calendar = Calendar.getInstance()
-                                    calendar.set(
-                                        calendar.get(Calendar.YEAR),
-                                        calendar.get(Calendar.MONTH),
-                                        calendar.get(Calendar.DAY_OF_MONTH),
-                                        calendar.get(Calendar.HOUR_OF_DAY),
-                                        calendar.get(Calendar.MINUTE),
-                                        calendar.get(Calendar.SECOND)
-                                    )
+                                    
                                     this.nextNotificationTimestamp = System.currentTimeMillis()
                                 }
                                 database.insert(backgroundJob)

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -685,6 +685,11 @@ class HealthStore(
                                     this.notificationId = notificationId
                                     this.timeUnit = parameters.timeUnit
                                     this.timeUnitGrouping = parameters.timeUnitGrouping
+
+                                    parameters.waitingPeriod?.let {
+                                        this.waitingPeriod = parameters.waitingPeriod
+                                        this.lastNotificationTimestamp = System.currentTimeMillis() - (parameters.waitingPeriod!!*1000)
+                                    }
                                 }
                                 database.insert(backgroundJob)
                             })

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -692,13 +692,14 @@ class HealthStore(
                                         parameters.notificationFrequencyGrouping!!
 
                                     val calendar = Calendar.getInstance()
-                                    val year = calendar.get(Calendar.YEAR)
-                                    val month = calendar.get(Calendar.MONTH)
-                                    val day = calendar.get(Calendar.DAY_OF_MONTH)
-                                    val hour = calendar.get(Calendar.HOUR_OF_DAY)
-                                    val minute = calendar.get(Calendar.MINUTE)
-                                    val second = calendar.get(Calendar.SECOND)
-                                    calendar.set(year, month, day, hour, minute, second)
+                                    calendar.set(
+                                        calendar.get(Calendar.YEAR),
+                                        calendar.get(Calendar.MONTH),
+                                        calendar.get(Calendar.DAY_OF_MONTH),
+                                        calendar.get(Calendar.HOUR_OF_DAY),
+                                        calendar.get(Calendar.MINUTE),
+                                        calendar.get(Calendar.SECOND)
+                                    )
 
                                     val timeNow = System.currentTimeMillis()
                                     this.nextNotificationTimestamp = timeNow

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -700,10 +700,7 @@ class HealthStore(
                                         calendar.get(Calendar.MINUTE),
                                         calendar.get(Calendar.SECOND)
                                     )
-
-                                    val timeNow = System.currentTimeMillis()
-                                    this.nextNotificationTimestamp = timeNow
-
+                                    this.nextNotificationTimestamp = System.currentTimeMillis()
                                 }
                                 database.insert(backgroundJob)
                             }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -686,10 +686,22 @@ class HealthStore(
                                     this.timeUnit = parameters.timeUnit
                                     this.timeUnitGrouping = parameters.timeUnitGrouping
 
-                                    parameters.waitingPeriod?.let {
-                                        this.waitingPeriod = parameters.waitingPeriod
-                                        this.lastNotificationTimestamp = System.currentTimeMillis() - (parameters.waitingPeriod!!*1000)
+                                    this.notificationFrequency = parameters.notificationFrequency
+                                    this.notificationFrequencyGrouping = parameters.notificationFrequencyGrouping
+
+                                    when (parameters.notificationFrequency) {
+                                        "SECOND" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*1000
+                                        "MINUTE" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*60*1000
+                                        "HOUR" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*60*60*1000
+                                        "DAY" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*24*60*60*1000
+                                        "WEEK" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*7*24*60*60*1000
+                                        "MONTH" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*30*24*60*60*1000
+                                        "YEAR" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*12*30*24*60*60*1000
+                                        else -> {
+                                            this.waitingPeriod = 0 //we don't want a waiting period in this case
+                                        }
                                     }
+                                    this.lastNotificationTimestamp = System.currentTimeMillis() - this.waitingPeriod!!
                                 }
                                 database.insert(backgroundJob)
                             })

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -686,8 +686,8 @@ class HealthStore(
                                     this.timeUnit = parameters.timeUnit
                                     this.timeUnitGrouping = parameters.timeUnitGrouping
 
-                                    this.notificationFrequency = parameters.notificationFrequency
-                                    this.notificationFrequencyGrouping = parameters.notificationFrequencyGrouping
+                                    this.notificationFrequency = parameters.notificationFrequency.toString()
+                                    this.notificationFrequencyGrouping = parameters.notificationFrequencyGrouping!!
 
                                     when (parameters.notificationFrequency) {
                                         "SECOND" -> this.waitingPeriod = parameters.notificationFrequencyGrouping!!*1000

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -691,28 +691,69 @@ class HealthStore(
                                     this.notificationFrequencyGrouping =
                                         parameters.notificationFrequencyGrouping!!
 
+                                    val calendar = Calendar.getInstance()
+                                    val year = calendar.get(Calendar.YEAR)
+                                    val month = calendar.get(Calendar.MONTH)
+                                    val day = calendar.get(Calendar.DAY_OF_MONTH)
+                                    val hour = calendar.get(Calendar.HOUR_OF_DAY)
+                                    val minute = calendar.get(Calendar.MINUTE)
+                                    val second = calendar.get(Calendar.SECOND)
+                                    calendar.set(year, month, day, hour, minute, second)
+
                                     when (parameters.notificationFrequency) {
-                                        "SECOND" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 1000
-                                        "MINUTE" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 60 * 1000
-                                        "HOUR" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 60 * 60 * 1000
-                                        "DAY" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 24 * 60 * 60 * 1000
-                                        "WEEK" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 7 * 24 * 60 * 60 * 1000
-                                        "MONTH" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 30 * 24 * 60 * 60 * 1000
-                                        "YEAR" -> this.waitingPeriod =
-                                            parameters.notificationFrequencyGrouping * 12 * 30 * 24 * 60 * 60 * 1000
-                                        else -> {
+                                        "SECOND" -> {
+                                            //this.waitingPeriod =
+                                                    //parameters.notificationFrequencyGrouping * 1000
+                                            this.waitingPeriod = parameters.notificationFrequencyGrouping * 1000
+                                            this.lastNotificationTimestamp = System.currentTimeMillis() - this.waitingPeriod!!
+                                            //calendar.add(Calendar.SECOND, -(notificationFrequencyGrouping))
+                                        }
+                                        "MINUTE" -> {
+                                            //this.waitingPeriod =
+                                                //parameters.notificationFrequencyGrouping * 60 * 1000
+                                            this.waitingPeriod = parameters.notificationFrequencyGrouping * 60 * 1000
+                                            this.lastNotificationTimestamp = System.currentTimeMillis() - this.waitingPeriod!!
+                                            //calendar.add(Calendar.MINUTE, -(notificationFrequencyGrouping))
+                                        }
+                                        "HOUR" -> {
+                                            //this.waitingPeriod =
+                                                //parameters.notificationFrequencyGrouping * 60 * 60 * 1000
+                                            TimeUnit.HOURS.toMillis(parameters.notificationFrequencyGrouping as Long)
+                                            calendar.add(Calendar.HOUR, -(notificationFrequencyGrouping))
+                                            this.lastNotificationTimestamp = calendar.timeInMillis
+                                        }
+                                        "DAY" -> {
+                                            //this.waitingPeriod =
+                                                //parameters.notificationFrequencyGrouping * 24 * 60 * 60 * 1000
+                                            calendar.add(Calendar.DAY_OF_MONTH, -(notificationFrequencyGrouping))
+                                            this.lastNotificationTimestamp = calendar.timeInMillis
+                                        }
+                                        "WEEK" -> {
                                             this.waitingPeriod =
-                                                0 //we don't want a waiting period in this case
+                                                parameters.notificationFrequencyGrouping * 7 * 24 * 60 * 60 * 1000
+                                            calendar.add(Calendar.WEEK_OF_MONTH, -(notificationFrequencyGrouping))
+                                            this.lastNotificationTimestamp = calendar.timeInMillis
+                                        }
+                                        "MONTH" -> {
+                                            this.waitingPeriod =
+                                                parameters.notificationFrequencyGrouping * 30 * 24 * 60 * 60 * 1000
+                                            calendar.add(Calendar.MONTH, -(notificationFrequencyGrouping))
+                                            this.lastNotificationTimestamp = calendar.timeInMillis
+                                        }
+                                        "YEAR" -> {
+                                            this.waitingPeriod =
+                                                parameters.notificationFrequencyGrouping * 12 * 30 * 24 * 60 * 60 * 1000
+                                            calendar.add(Calendar.YEAR, -(notificationFrequencyGrouping))
+                                            this.lastNotificationTimestamp = calendar.timeInMillis
+                                        }
+                                        else -> {
+                                            //this.waitingPeriod =
+                                                //0 //we don't want a waiting period in this case
                                         }
                                     }
-                                    this.lastNotificationTimestamp =
-                                        System.currentTimeMillis() - this.waitingPeriod!!
+                                    //this.lastNotificationTimestamp = calendar.timeInMillis
+                                    //this.lastNotificationTimestamp =
+                                        //System.currentTimeMillis() - this.waitingPeriod!!
                                 }
                                 database.insert(backgroundJob)
                             }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- This PR adds the implementation of the NotificationFrequency, also known as waiting period, on Android.
- For NotificationFrequency equal to SECOND or MINUTE, we always wait for the next full SECOND / MINUTE to pass before sending another notification. For the rest of them, like HOUR and DAY, we only wait for the beginning of the next time unit. For example, if we send a notification at 4:55PM and at 5:00PM we have a new notification to be sent, we will send it, because we are in a new hour. On the other hand, if the frequency is MINUTE and we send a notification at 4:55PM and 30 seconds, we will wait until 4:56PM and 30 seconds to send a new notification.

- This PR also includes the work done by @nflsilva regarding the Migration of the Room database, since we added some new values to the BackgroundJob table.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1240

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally on Android 11. Tested all possible NotificationFrequency values. Also built with MABS 8 and MABS 7.2.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
