### PR TITLE
RMET-1235 H&F Plugin - Reset nextNotificationTimestamp in update

### DIFF
--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthStore.kt
@@ -833,9 +833,11 @@ class HealthStore(
                     }
                     if(parameters.notificationFrequency != null){
                         job.notificationFrequency = parameters.notificationFrequency
+                        job.nextNotificationTimestamp = 0
                     }
                     if(parameters.notificationFrequencyGrouping != null){
                         job.notificationFrequencyGrouping = parameters.notificationFrequencyGrouping
+                        job.nextNotificationTimestamp = 0
                     }
                     if(notification != null){
                         if(parameters.notificationHeader != null){


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds a small fix to reset the nextNotificationTimestamp to 0 when the notificationFrequency or the notificationFrequencyGrouping change.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1235

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested locally in Android 11. MABS 7.2 and 8.0 

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
