### PR TITLE
RMET-1268 H&F Plugin - Fixing package name for ClickActivity class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+- Fixed ClickActivity package name on plugin.xml (https://outsystemsrd.atlassian.net/browse/RMET-1268)
+
 - Implemented Unit Tests for UpdateBackgroundJob feature on Android (https://outsystemsrd.atlassian.net/browse/RMET-1235)
 
 - Implemented Unit Tests for DeleteBackgroundJob feature on Android (https://outsystemsrd.atlassian.net/browse/RMET-1232)

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
       <activity
             android:exported="false"
             android:launchMode="singleTask"
-            android:name="com.outsystems.plugins.healthfitnesslib.background.ClickActivity"
+            android:name="com.outsystems.plugins.healthfitness.background.ClickActivity"
             android:theme="@android:style/Theme.NoDisplay" />
         
     </config-file>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR fixes a bug found that when clicking a notification from the notification panel, the app would not open. Fixed the package name of the ClickActivity.


## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1268

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS builds working. Tested with MABS build and clicking the notification opens the app.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
