### PR TITLE
Adds JaCoCo and Sonarqube support

### DIFF
--- a/tests/android/HealthFitnessTests/app/build.gradle
+++ b/tests/android/HealthFitnessTests/app/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
+apply plugin: 'jacoco'
+apply plugin: "org.sonarqube"
+
+jacoco {
+    toolVersion = "0.8.7"
+}
 
 android {
     compileSdkVersion 30
@@ -16,11 +22,20 @@ android {
 
         testOptions {
             unitTests.returnDefaultValues = true
+                android.testOptions.unitTests.all {
+                    jacoco {
+                        includeNoLocationClasses = true
+                        excludes = ['jdk.internal.*']
+                    }
+            }
         }
 
     }
 
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
@@ -30,6 +45,53 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
+
+    task createTestReport(type: JacocoReport) {
+    	group = "Reporting"
+
+   	reports {
+       		 xml.enabled = true
+       		 html.enabled = true
+    	}
+
+   	    def fileFilter = ['**/R.class',
+      	                  '**/R$*.class',
+                          '**/BuildConfig.*',
+                          '**/*$ViewInjector*.*',
+                          '**/*$ViewBinder*.*',
+                          '**/*$MembersInjector*.*',
+                          '**/Manifest*.*',
+                          '**/*Test*.*',
+                          'android/**/*.*']
+	    def debugTree = fileTree(dir: "${buildDir}/tmp/kotlin-classes/debugUnitTest", excludes: fileFilter)
+    	def mainSrc = "${project.projectDir}/../../../../src/android"
+
+    	sourceDirectories.from = files([mainSrc])
+        additionalSourceDirs.from = files([mainSrc])
+    	classDirectories.from = files([debugTree])
+    	executionData.from = files("${project.buildDir}/jacoco/testDebugUnitTest.exec")
+	}
+
+    sonarqube {
+        properties {
+            property "sonar.host.url", "https://sonarcloud.io"
+            property "sonar.organization", "outsystemsrd"
+            property "sonar.projectKey", "OutSystems_cordova-outsystems-healthfitness"
+            property "sonar.projectName", "OutSystems_cordova-outsystems-healthfitness"
+            property "sonar.projectBaseDir", "$project.rootDir/../../../"
+            property "sonar.tests", "$project.rootDir/app/src"
+            property "sonar.sourceEncoding", "UTF-8"
+            property "sonar.sources", "$project.rootDir/../../../src/android"
+            property "sonar.exclusions", 
+                    'build/**' +
+                    '*.json,' +
+                    '**/.gradle/**,' +
+                    '**/R.class'
+            property "sonar.java.coveragePlugin", "jacoco"
+            property "sonar.coverage.jacoco.xmlReportPaths", "$project.rootDir/app/build/reports/jacoco/createTestReport/createTestReport.xml"
+        }
+    }
+
 }
 dependencies {
 

--- a/tests/android/HealthFitnessTests/app/src/test/java/com/outsystems/plugins/healthfitness/mock/AndroidPlatformMock.kt
+++ b/tests/android/HealthFitnessTests/app/src/test/java/com/outsystems/plugins/healthfitness/mock/AndroidPlatformMock.kt
@@ -7,7 +7,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.outsystems.plugins.core.AndroidPlatformInterface
 import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class AndroidPlatformMock : AndroidPlatformInterface {
 
     var sendPluginResultCompletion: ((resultVariable: String, error: Pair<Int, String>?) -> Unit)? = null

--- a/tests/android/HealthFitnessTests/build.gradle
+++ b/tests/android/HealthFitnessTests/build.gradle
@@ -9,6 +9,8 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    	classpath "org.jacoco:org.jacoco.core:0.8.7"
+        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Description
So we can get test coverage reports, this PR adds JaCoCo to estimate the unit test coverage and Sonarqube to centralise those reports

Also removing an annotation from AndroidPlatformMock. From what I've seen it's not needed and it was breaking the unit tests as the JUnit runner broken when running a class without tests

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
