### PR TITLE
RMET-1460 H&F Plugin - Fix to use constant literal value because of MABS 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+- Fixed issue with MABS 7 Android build because of PendingIntent.FLAG_MUTABLE (https://outsystemsrd.atlassian.net/browse/RMET-1460)
+
 ## [Version 1.2.0]
 
 - Implemented Unit Tests for BackgroundJob operations on iOS (https://outsystemsrd.atlassian.net/browse/RMET-1210)

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -61,7 +61,7 @@ class VariableUpdateService : BroadcastReceiver() {
 
         //build intent to call the ClickActivity
         val myIntent = Intent(context, ClickActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(context, 1, myIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+        val pendingIntent = PendingIntent.getActivity(context, 1, myIntent, PendingIntent.FLAG_UPDATE_CURRENT or 33554432)
 
         //get icon for notification
         val icon = getResourceId(context, "mipmap/ic_launcher")

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/background/VariableUpdateService.kt
@@ -60,6 +60,7 @@ class VariableUpdateService : BroadcastReceiver() {
         }
 
         //build intent to call the ClickActivity
+        //when MABS 7 stops being supported, we can use PendingIntent.FLAG_MUTABLE instead of 33554432
         val myIntent = Intent(context, ClickActivity::class.java)
         val pendingIntent = PendingIntent.getActivity(context, 1, myIntent, PendingIntent.FLAG_UPDATE_CURRENT or 33554432)
 

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthFitnessManager.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthFitnessManager.kt
@@ -198,6 +198,6 @@ class HealthFitnessManager(var context : Context, var activity : Activity? = nul
         val intent = Intent(context, VariableUpdateService::class.java)
         intent.putExtra(VariableUpdateService.VARIABLE_NAME, variableName)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        return PendingIntent.getBroadcast(context, variableName.hashCode(), intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+        return PendingIntent.getBroadcast(context, variableName.hashCode(), intent, PendingIntent.FLAG_UPDATE_CURRENT or 33554432)
     }
 }

--- a/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthFitnessManager.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/oshealthfitnesslibrary/store/HealthFitnessManager.kt
@@ -195,6 +195,7 @@ class HealthFitnessManager(var context : Context, var activity : Activity? = nul
 
     private fun getSubscritionPendingIntent(variableName : String) : PendingIntent {
         //do the actual subscription to the variable updates
+        //when MABS 7 stops being supported, we can use PendingIntent.FLAG_MUTABLE instead of 33554432
         val intent = Intent(context, VariableUpdateService::class.java)
         intent.putExtra(VariableUpdateService.VARIABLE_NAME, variableName)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- MABS 7 builds for an app with the plugin were breaking. 
- For the MABS 7 builds, we cannot use PendingIntent.FLAG_MUTABLE, since this was only introduced in API Level 31. Instead, we need to use the corresponding literal value which is 33554432

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1460

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Built on MABS 7 and MABS 8. Tested plugin, receiving notifications for STEPS and WEIGHT.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
