### PR TITLE
RMET-1689 ::: Fix - App Store submission background identifier requeired 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Version 1.2.5]
+ - Added to the info.plist file a property to identify the background tasks used in the plugin.(https://outsystemsrd.atlassian.net/browse/RMET-1689) 
+
 ## [Version 1.2.4]
 
 - Assign the "averageOperations" value for Blood Glucose's optionsAllowed property (https://outsystemsrd.atlassian.net/browse/RPM-2623)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.healthfitness",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Health & Fitness cordova plugin for OutSystems applications.",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.healthfitness" version="1.2.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.healthfitness" version="1.2.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>HealthFitness</name>
   <description>Health &amp; Fitness cordova plugin for OutSystems applications.</description>
   <author>OutSystems Inc</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -115,15 +115,9 @@
     <config-file target="*-Info.plist" parent="UIBackgroundModes">
       <array>
         <string>fetch</string>
-        <string>processing</string>
       </array>
     </config-file>
-
-    <key>BGTaskSchedulerPermittedIdentifiers</key>
-    <array>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-    </array>
-
+    
     <!-- Entitlements -->
     <config-file target="*/Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
       <true/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -115,9 +115,16 @@
     <config-file target="*-Info.plist" parent="UIBackgroundModes">
       <array>
         <string>fetch</string>
+        <string>processing</string>
       </array>
     </config-file>
-    
+
+    <config-file target="*-Info.plist" parent="BGTaskSchedulerPermittedIdentifiers">
+      <array>
+        <string>com.outsystems.health.default</string>
+      </array>
+    </config-file>
+
     <!-- Entitlements -->
     <config-file target="*/Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
       <true/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -119,6 +119,11 @@
       </array>
     </config-file>
 
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+        <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    </array>
+
     <!-- Entitlements -->
     <config-file target="*/Entitlements-Debug.plist" parent="com.apple.developer.healthkit">
       <true/>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added to the info.plist file a property to identify the background tasks used in the plugin.
The property added is: BGTaskSchedulerPermittedIdentifiers.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manually tests executed 

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
