### PR TITLE
RMET-1684 ::: Request Notification Permissions - Android 13 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Version 1.2.9]
+- Feat: [Android] Implement request permissions, feature needed to android 13 compliance.
+
 ## [Version 1.2.8]
 
 - Fix: [iOS] Apply the AdvancedQueryDataPoint structure and AdvancedQueryResultType parameter to Category and Correlation variables as well.

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@
       <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
       <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
       <uses-permission android:name="android.permission.BODY_SENSORS" />
+      <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND" />
     </config-file>
 
     <!-- HealthFitness Plugin -->

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -23,9 +23,11 @@ dependencies{
 
     implementation 'com.google.code.findbugs:jsr305:1.3.9'
 
-    implementation("com.github.outsystems:oscore-android:1.1.0@aar")
-    implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
+    implementation("com.github.outsystems:oscore-android:1.2.0@aar")
+    implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
     implementation("com.github.outsystems:oshealthfitness-android:1.0.0@aar")
+    implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
+    
 
     def roomVersion = "2.4.2"
     implementation("androidx.room:room-runtime:$roomVersion")

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.gson.Gson
+import com.outsystems.osnotificationpermissions.*
 import com.outsystems.plugins.healthfitness.background.BackgroundJobParameters
 import com.outsystems.plugins.healthfitness.background.DatabaseManager
 import com.outsystems.plugins.healthfitness.background.UpdateBackgroundJobParameters
@@ -22,6 +23,7 @@ class OSHealthFitness : CordovaImplementation() {
 
     var healthStore: HealthStoreInterface? = null
     val gson by lazy { Gson() }
+    var notificationPermissions = OSNotificationPermissions()
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
         super.initialize(cordova, webView)
@@ -178,6 +180,8 @@ class OSHealthFitness : CordovaImplementation() {
     }
 
     private fun setBackgroundJob(args: JSONArray) {
+        notificationPermissions.requestNotificationPermission(this, ACTIVITY_NOTIFICATION_PERMISSIONS_REQUEST_CODE)
+        
         //process parameters
         val parameters = gson.fromJson(args.getString(0), BackgroundJobParameters::class.java)
         healthStore?.setBackgroundJob(
@@ -278,5 +282,6 @@ class OSHealthFitness : CordovaImplementation() {
 
     companion object {
         const val ACTIVITY_LOCATION_PERMISSIONS_REQUEST_CODE = 1
+        const val ACTIVITY_NOTIFICATION_PERMISSIONS_REQUEST_CODE = 2
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Since Android 13 now requires permission just like iOS we are want the same feature on Android.
The prompt to the user will be at the same moment that iOS, when the user creates the first background job.

Adds the `BODY_SENSORS_BACKGROUND ` to the Manifest.xml. Also a change required by Android 13.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
Closes issues: https://outsystemsrd.atlassian.net/browse/RMET-1684,
https://outsystemsrd.atlassian.net/browse/RMET-1685

To create the request permission we implemented in a base level, updating OSCore-Android, OSCordova-Android and created a new Library called OSNotificationPermissionsLib-Android.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
