### PR TITLE
RMET-2041 - Health & Fitness Plugin - Add safe call to avoid build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+- Fix: [Android] Add safe call to avoid build error. (https://outsystemsrd.atlassian.net/browse/RMET-2041)
+
 ## [Version 1.2.9]
 - Fix: [iOS] Clear milliseconds from background job's date range lower bound, as `HKStatistics` uses for its start date. This way, the data block is not discarded from the final results (https://outsystemsrd.atlassian.net/browse/RMET-1836).
 - Feat: [Android] Implement request permissions, feature needed to android 13 compliance.

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -251,7 +251,7 @@ class OSHealthFitness : CordovaImplementation() {
         if (status != ConnectionResult.SUCCESS) {
             var result: Pair<String, String>? = null
             result = if (googleApiAvailability.isUserResolvableError(status)) {
-                googleApiAvailability.getErrorDialog(cordova.activity, status, 1).show()
+                googleApiAvailability.getErrorDialog(cordova.activity, status, 1)?.show()
                 Pair(HealthFitnessError.GOOGLE_SERVICES_RESOLVABLE_ERROR.code.toString(), HealthFitnessError.GOOGLE_SERVICES_RESOLVABLE_ERROR.message)
             } else {
                 Pair(HealthFitnessError.GOOGLE_SERVICES_ERROR.code.toString(), HealthFitnessError.GOOGLE_SERVICES_ERROR.message)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Build error happening in an app with both the Health & Fitness and the FB Cloud Messaging plugin. Changing the call to a safe call fixes the build error.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2041

This closes and RPM.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested with MABS 8.1 build.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
