### PR TITLE
RMET-2036 :: Replaced jcenter by mavenCentral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### 16-12-2022
+- Replaced jcenter with more up to date mavenCentral [RMET-2036](https://outsystemsrd.atlassian.net/browse/RMET-2036)
+
 ## [Version 1.2.11]
 - Fix: [iOS] Replace the old `OSCore` framework for the new `OSCommonPluginLib` pod.
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
     }
 
     dependencies {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         google()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
## Description
- Replaced the deprecated `jcenter` repository by a more updated `mavenCentral`

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2036

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on MABS 8 and MABS 9 builds, on Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
