### PR TITLE
RMET-3046 H&F Cordova Plugin - Migrate RequestPermissions to HealthConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
-## 2023-08-25
+## 2024-02-01
 - Re-implemented RequestPermissions feature (https://outsystemsrd.atlassian.net/browse/RMET-3046).
 
 ## [Version 1.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+## 2023-08-25
+- Re-implemented RequestPermissions feature (https://outsystemsrd.atlassian.net/browse/RMET-3046).
+
 ## [Version 1.4.0]
 
 ## 2023-08-25

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.2@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.4@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.1@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.2@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.1@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -17,6 +17,7 @@ import com.outsystems.plugins.healthfitness.store.*
 import com.outsystems.plugins.oscordova.CordovaImplementation
 import org.apache.cordova.*
 import org.json.JSONArray
+import org.json.JSONException
 
 class OSHealthFitness : CordovaImplementation() {
     override var callbackContext: CallbackContext? = null
@@ -85,29 +86,15 @@ class OSHealthFitness : CordovaImplementation() {
         return true
     }
 
-
-    //create array of permission oauth
     private fun initAndRequestPermissions(args: JSONArray) {
         try {
-            val customPermissions = args.getString(0)
-            val allVariables = args.getString(1)
-            val fitnessVariables = args.getString(2)
-            val healthVariables = args.getString(3)
-            val profileVariables = args.getString(4)
-
-            val customVariablesPermissions = gson.fromJson(customPermissions, Array<HealthFitnessPermission>::class.java)
-            val allVariablesPermissions = gson.fromJson(allVariables, HealthFitnessGroupPermission::class.java)
-            val fitnessVariablesPermissions = gson.fromJson(fitnessVariables, HealthFitnessGroupPermission::class.java)
-            val healthVariablesPermissions = gson.fromJson(healthVariables, HealthFitnessGroupPermission::class.java)
-            val profileVariablesPermissions = gson.fromJson(profileVariables, HealthFitnessGroupPermission::class.java)
-
             healthConnectViewModel.initAndRequestPermissions(
                 getActivity(),
-                customVariablesPermissions,
-                allVariablesPermissions,
-                fitnessVariablesPermissions,
-                healthVariablesPermissions,
-                profileVariablesPermissions,
+                gson.fromJson(args.getString(0), Array<HealthFitnessPermission>::class.java),
+                gson.fromJson(args.getString(1), HealthFitnessGroupPermission::class.java),
+                gson.fromJson(args.getString(2), HealthFitnessGroupPermission::class.java),
+                gson.fromJson(args.getString(3), HealthFitnessGroupPermission::class.java),
+                gson.fromJson(args.getString(4), HealthFitnessGroupPermission::class.java),
                 {
                     setAsActivityResultCallback()
                 },
@@ -115,9 +102,24 @@ class OSHealthFitness : CordovaImplementation() {
                     sendPluginResult(null, Pair(it.code.toString(), it.message))
                 }
             )
-
         } catch (hse: HealthStoreException) {
             sendPluginResult(null, Pair(hse.error.code.toString(), hse.error.message))
+        } catch (e: JSONException) {
+            sendPluginResult(
+                null,
+                Pair(
+                    HealthFitnessError.PARSING_PARAMETERS_ERROR.code.toString(),
+                    HealthFitnessError.PARSING_PARAMETERS_ERROR.message
+                )
+            )
+        } catch (e: Exception) {
+            sendPluginResult(
+                null,
+                Pair(
+                    HealthFitnessError.REQUEST_PERMISSIONS_GENERAL_ERROR.code.toString(),
+                    HealthFitnessError.REQUEST_PERMISSIONS_GENERAL_ERROR.message
+                )
+            )
         }
     }
 

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -290,9 +290,6 @@ class OSHealthFitness : CordovaImplementation() {
         )
     }
 
-
-
-
     override fun areGooglePlayServicesAvailable(): Boolean {
         val googleApiAvailability = GoogleApiAvailability.getInstance()
         val status = googleApiAvailability.isGooglePlayServicesAvailable(getActivity())

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -86,6 +86,7 @@ class OSHealthFitness : CordovaImplementation() {
 
     //create array of permission oauth
     private fun initAndRequestPermissions(args: JSONArray) {
+        setAsActivityResultCallback()
         try {
             val customPermissions = args.getString(0)
             val allVariables = args.getString(1)
@@ -107,7 +108,7 @@ class OSHealthFitness : CordovaImplementation() {
                 healthVariablesPermissions,
                 profileVariablesPermissions
             )
-            setAsActivityResultCallback()
+
         } catch (hse: HealthStoreException) {
             sendPluginResult(null, Pair(hse.error.code.toString(), hse.error.message))
         }

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -284,8 +284,8 @@ class OSHealthFitness : CordovaImplementation() {
             {
                 sendPluginResult("success", null)
             },
-            {error ->
-                sendPluginResult(null, Pair(error.code.toString(), error.message))
+            {
+                sendPluginResult(null, Pair(it.code.toString(), it.message))
             }
         )
     }

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -27,6 +27,7 @@ class OSHealthFitness : CordovaImplementation() {
     lateinit var healthConnectViewModel: HealthConnectViewModel
     lateinit var healthConnectRepository: HealthConnectRepository
     lateinit var healthConnectDataManager: HealthConnectDataManager
+    lateinit var healthConnectHelper: HealthConnectHelper
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
         super.initialize(cordova, webView)
@@ -36,7 +37,8 @@ class OSHealthFitness : CordovaImplementation() {
 
         healthConnectDataManager = HealthConnectDataManager()
         healthConnectRepository = HealthConnectRepository(healthConnectDataManager)
-        healthConnectViewModel = HealthConnectViewModel(healthConnectRepository)
+        healthConnectHelper = HealthConnectHelper()
+        healthConnectViewModel = HealthConnectViewModel(healthConnectRepository, healthConnectHelper)
     }
 
     override fun execute(
@@ -86,7 +88,6 @@ class OSHealthFitness : CordovaImplementation() {
 
     //create array of permission oauth
     private fun initAndRequestPermissions(args: JSONArray) {
-        setAsActivityResultCallback()
         try {
             val customPermissions = args.getString(0)
             val allVariables = args.getString(1)
@@ -106,7 +107,13 @@ class OSHealthFitness : CordovaImplementation() {
                 allVariablesPermissions,
                 fitnessVariablesPermissions,
                 healthVariablesPermissions,
-                profileVariablesPermissions
+                profileVariablesPermissions,
+                {
+                    setAsActivityResultCallback()
+                },
+                {
+                    sendPluginResult(null, Pair(it.code.toString(), it.message))
+                }
             )
 
         } catch (hse: HealthStoreException) {
@@ -277,7 +284,8 @@ class OSHealthFitness : CordovaImplementation() {
             },
             {error ->
                 sendPluginResult(null, Pair(error.code.toString(), error.message))
-            })
+            }
+        )
     }
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR re-implements the `RequestPermissions` feature - `initAndRequestPermissions` method in the Cordova bridge.
- It also updates the version of the `OSHealthFitnessLib-Android` library

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

We're migrating the H&F library from the Google Fit Android API to the Health Connect SDK.

References: https://outsystemsrd.atlassian.net/browse/RMET-3046

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Unit tests for the `RequestPermissions` feature were added to `src/test/kotlin/com/outsystems/plugins/healthfitness/RequestPermissionsTest.kt`.

- MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=94bf797e81f8658511d4c27a556a8bd06ae16352
- MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=017c0cbd5c4c3fc5ab855f4b01b19bd909b904d8

- Tested in Android 14 and Android 13.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
