### PR TITLE
RMET-3048 :: Migrate GetLastRecord to HealthConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2024-02-08
+- Re-implement `GetLastRecord` feature:
+    - GetFitnessData (https://outsystemsrd.atlassian.net/browse/RMET-3048)
+    - GetHealthData (https://outsystemsrd.atlassian.net/browse/RMET-3065)
+    - GetProfileData (https://outsystemsrd.atlassian.net/browse/RMET-3066)
+
 ## 2024-02-05
 - Re-implemented WriteProfieleData feature (https://outsystemsrd.atlassian.net/browse/RMET-3049).
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.6@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.8@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.5@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.6@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -18,7 +18,6 @@ import com.outsystems.plugins.oscordova.CordovaImplementation
 import org.apache.cordova.*
 import org.json.JSONArray
 import org.json.JSONException
-import java.lang.IllegalArgumentException
 
 class OSHealthFitness : CordovaImplementation() {
     override var callbackContext: CallbackContext? = null


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- This PR re-implements the `GetLastRecord` feature, which deals with:
  - `GetProfileData`
  - `GetHealthData`
  - `GetFitnessData`
- It also includes a refactor on the `writeData` method of the Cordova bridge, where we remove a validation that is already done on the Android library, and so there's no need to do it here.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References:
- https://outsystemsrd.atlassian.net/browse/RMET-3048
- https://outsystemsrd.atlassian.net/browse/RMET-3065
- https://outsystemsrd.atlassian.net/browse/RMET-3066

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested in Android 14 Pixel 7 and Android 13 Samsung S20 FE.

## Screenshots (if appropriate)

- Calling the `GetHealthData` client action for the `BLOOD_PRESSURE` variable:

![image](https://github.com/OutSystems/cordova-outsystems-healthfitness/assets/27646996/e0df32fa-3918-40ff-bfd1-c0f2d6fac9f2)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
