### PR TITLE
RMET- 3142 H&F Plugin - Hook for permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2024-02-27
+- Implemented hook for permissions  (https://outsystemsrd.atlassian.net/browse/RMET-3142).
+
 ## 2024-02-26
 - Implemented `Show app's privacy policy dialog`  (https://outsystemsrd.atlassian.net/browse/RMET-3145).
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -11,6 +11,7 @@ module.exports = async function (context) {
     const configXML = path.join(projectRoot, 'config.xml');
     const configParser = new ConfigParser(configXML);
         
+    // add health connect permissions to AndroidManifest.xml and health_permissions.xml files
     addPermissionsToManifest(configParser, projectRoot);
 };
 
@@ -99,28 +100,37 @@ function addPermissionsToManifest(configParser, projectRoot) {
     var speedSet = false
     var distanceSet = false
 
-
+    const parser = new DOMParser();
 
     // Android >= 14 dependencies should be included directly in the AndroidManifest.xml file
-    // Android <= 13 dependencies should be included in a separate XML file
-
     // Read the AndroidManifest.xml file
     const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
     const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');
 
-
     // Parse the XML string
-    const parser = new DOMParser();
     const manifestXmlDoc = parser.parseFromString(manifestXmlString, 'text/xml');
+
+    // Android <= 13 dependencies should be included in a separate XML file
+    // Create the health_permissions.xml file
+    const permissionsXmlDoc = parser.parseFromString('<?xml version="1.0" encoding="utf-8"?><resources><array name="health_permissions"></array></resources>', 'text/xml');
+    // Get the <array> element
+    const arrayElement = xmlDoc.getElementsByTagName('array')[0];
  
 
     // heartRate
     if (heartRate == "ReadWrite" || heartRate == "Read") {
         heartRateSet = true
 
+        // Android >= 14
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        // Android <= 13
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (heartRate == "ReadWrite" || heartRate == "Write") {
@@ -129,6 +139,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEART_RATE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // steps
@@ -138,6 +153,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_STEPS');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (steps == "ReadWrite" || steps == "Write") {
@@ -146,6 +166,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_STEPS');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // weight
@@ -155,6 +180,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_WEIGHT');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (weight == "ReadWrite" || weight == "Write") {
@@ -163,6 +193,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_WEIGHT');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // height
@@ -172,6 +207,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEIGHT');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (height == "ReadWrite" || height == "Write") {
@@ -180,6 +220,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEIGHT');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // calories
@@ -189,6 +234,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_TOTAL_CALORIES_BURNED');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (calories == "ReadWrite" || calories == "Write") {
@@ -197,6 +247,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // sleep
@@ -206,6 +261,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SLEEP');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (sleep == "ReadWrite" || sleep == "Write") {
@@ -214,6 +274,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SLEEP');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // blood pressure
@@ -223,6 +288,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_PRESSURE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (bloodPressure == "ReadWrite" || bloodPressure == "Write") {
@@ -231,6 +301,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_PRESSURE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // blood glucose
@@ -240,6 +315,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_GLUCOSE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (bloodGlucose == "ReadWrite" || bloodGlucose == "Write") {
@@ -248,6 +328,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_GLUCOSE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // body fat
@@ -257,6 +342,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BODY_FAT');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (bodyFat == "ReadWrite" || bodyFat == "Write") {
@@ -265,6 +355,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BODY_FAT');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // bmr
@@ -274,6 +369,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BASAL_METABOLIC_RATE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (bmr == "ReadWrite" || bmr == "Write") {
@@ -282,6 +382,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // speed
@@ -291,6 +396,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SPEED');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (speed == "ReadWrite" || speed == "Write") {
@@ -299,6 +409,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SPEED');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // distance
@@ -308,6 +423,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_DISTANCE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     if (distance == "ReadWrite" || distance == "Write") {
@@ -316,6 +436,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
+
+        const newItem = permissionsXmlDoc.createElement('item');
+        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_DISTANCE');
+        newItem.appendChild(textNode);
+        arrayElement.appendChild(newItem);
     }
 
     // process fitness variables
@@ -327,24 +452,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_STEPS');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!caloriesSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_TOTAL_CALORIES_BURNED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!speedSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SPEED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!distanceSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_DISTANCE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
     }
@@ -357,24 +502,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_STEPS');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!caloriesSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!speedSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SPEED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!distanceSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_DISTANCE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
     }
@@ -388,24 +553,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!sleepSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SLEEP');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bloodPressureSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_PRESSURE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bloodGlucoseSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_GLUCOSE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
     }
@@ -418,24 +603,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEART_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!sleepSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SLEEP');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bloodPressureSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_PRESSURE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bloodGlucoseSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_GLUCOSE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
     }
@@ -449,24 +654,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_WEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!heightSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bodyFatSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BODY_FAT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bmrSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BASAL_METABOLIC_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
     }
@@ -479,24 +704,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_WEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!heightSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bodyFatSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BODY_FAT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!bmrSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
     }
@@ -511,24 +756,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_STEPS');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!fitnessSet && !caloriesSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_TOTAL_CALORIES_BURNED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!fitnessSet && !speedSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SPEED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!fitnessSet && !distanceSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_DISTANCE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         // health
@@ -536,24 +801,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!healthSet && !sleepSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SLEEP');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!healthSet && !bloodPressureSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_PRESSURE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!healthSet && !bloodGlucoseSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_GLUCOSE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         // profile
@@ -561,24 +846,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_WEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!profileSet && !heightSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!profileSet && !bodyFatSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BODY_FAT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!profileSet && !bmrSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BASAL_METABOLIC_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
         
     }
@@ -590,24 +895,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_STEPS');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!fitnessSet && !caloriesSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!fitnessSet && !speedSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SPEED');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!fitnessSet && !distanceSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_DISTANCE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         // health
@@ -615,24 +940,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEART_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!healthSet && !sleepSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SLEEP');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!healthSet && !bloodPressureSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_PRESSURE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!healthSet && !bloodGlucoseSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_GLUCOSE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         // profile
@@ -640,24 +985,44 @@ function addPermissionsToManifest(configParser, projectRoot) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_WEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!profileSet && !heightSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEIGHT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!profileSet && !bodyFatSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BODY_FAT');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
 
         if (!profileSet && !bmrSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
             manifestXmlDoc.documentElement.appendChild(newPermission);
+
+            const newItem = permissionsXmlDoc.createElement('item');
+            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+            newItem.appendChild(textNode);
+            arrayElement.appendChild(newItem);
         }
         
     }
@@ -672,46 +1037,82 @@ function addPermissionsToManifest(configParser, projectRoot) {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
+
+                const newItem = permissionsXmlDoc.createElement('item');
+                const textNode = permissionsXmlDoc.createTextNode(permission.name);
+                newItem.appendChild(textNode);
+                arrayElement.appendChild(newItem);
             });
             
             fitnessPermissionsWrite.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
+
+                const newItem = permissionsXmlDoc.createElement('item');
+                const textNode = permissionsXmlDoc.createTextNode(permission.name);
+                newItem.appendChild(textNode);
+                arrayElement.appendChild(newItem);
             });
     
             healthPermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
+
+                const newItem = permissionsXmlDoc.createElement('item');
+                const textNode = permissionsXmlDoc.createTextNode(permission.name);
+                newItem.appendChild(textNode);
+                arrayElement.appendChild(newItem);
             });
             
             healthPermissionsWrite.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
+
+                const newItem = permissionsXmlDoc.createElement('item');
+                const textNode = permissionsXmlDoc.createTextNode(permission.name);
+                newItem.appendChild(textNode);
+                arrayElement.appendChild(newItem);
             });
     
             profilePermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
+
+                const newItem = permissionsXmlDoc.createElement('item');
+                const textNode = permissionsXmlDoc.createTextNode(permission.name);
+                newItem.appendChild(textNode);
+                arrayElement.appendChild(newItem);
             });
             
             profilePermissionsWrite.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
+
+                const newItem = permissionsXmlDoc.createElement('item');
+                const textNode = permissionsXmlDoc.createTextNode(permission.name);
+                newItem.appendChild(textNode);
+                arrayElement.appendChild(newItem);
             });
 
         }
 
     // Serialize the updated XML document back to string
     const serializer = new XMLSerializer();
-    const updatedManifestXmlString = serializer.serializeToString(manifestXmlDoc);
 
+    // Android >= 14
+    const updatedManifestXmlString = serializer.serializeToString(manifestXmlDoc);
     // Write the updated XML string back to the same file
     fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');
-    
+
+    // Android <= 13
+    const updatedPermissionsXmlString = serializer.serializeToString(permissionsXmlDoc);
+    const permissionsXmlFilePath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/health_permissions.xml');
+    // Write the updated XML string back to the same file
+    fs.writeFileSync(permissionsXmlFilePath, updatedPermissionsXmlString, 'utf-8');
 
 }

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1161,6 +1161,9 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     const notificationTitle = configParser.getPlatformPreference('BackgroundNotificationTitle', 'android');
     const notificationDescription = configParser.getPlatformPreference('BackgroundNotificationDescription', 'android');
 
+    console.log('BackgroundNotificationTitle: ' + notificationTitle);
+    console.log('BackgroundNotificationDescription: ' + notificationDescription);
+
     // we only want a default value for the title
     if (notificationTitle == "") {
         notificationTitle = "Measuring your health and fitness data."
@@ -1173,11 +1176,13 @@ function copyNotificationContent(configParser, projectRoot, parser) {
 
     const titleElement = stringsXmlDoc.getElementById('background_notification_title');
     if (titleElement) {
+        console.log('Setting Title');
         titleElement.textContent = notificationTitle;
     }
 
     const descriptionElement = stringsXmlDoc.getElementById('background_notification_description');
     if (descriptionElement) {
+        console.log('Setting Description');
         descriptionElement.textContent = notificationDescription;
     }
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1178,6 +1178,8 @@ function copyNotificationContent(configParser, projectRoot, parser) {
 
     stringsXmlDoc.getElementsByTagName
 
+    /*
+
     const titleElement = stringsXmlDoc.getElementById('background_notification_title');
     console.log('titleElement: ' + titleElement);
     if (titleElement) {
@@ -1190,6 +1192,22 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     if (descriptionElement) {
         console.log('Setting Description');
         descriptionElement.textContent = notificationDescription;
+    }
+    */
+
+    const stringElements = stringsXmlDoc.getElementsByTagName('string');
+
+    // Set text for each <string> element
+    for (let i = 0; i < stringElements.length; i++) {
+        const name = stringElements[i].getAttribute('name');
+        if (name == "background_notification_title") {
+            console.log('Setting Title');
+            stringElements[i].textContent = notificationTitle;
+        }
+        else if (name == "background_notification_description") {
+            console.log('Setting Description');
+            stringElements[i].textContent = notificationDescription;
+        }
     }
 
     // serialize the updated XML document back to string

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -114,7 +114,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
     // Create the health_permissions.xml file
     const permissionsXmlDoc = parser.parseFromString('<?xml version="1.0" encoding="utf-8"?><resources><array name="health_permissions"></array></resources>', 'text/xml');
     // Get the <array> element
-    const arrayElement = xmlDoc.getElementsByTagName('array')[0];
+    const arrayElement = permissionsXmlDoc.getElementsByTagName('array')[0];
  
 
     // heartRate

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -677,6 +677,10 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
     console.log('allVariables: ' + allVariables);
 
+    if (allVariables === undefined) {
+        console.log('allVariables is undefined');
+    }
+
 
     // if there is no AllVariables nor anything else, then by default we add all the permissions
     if (allVariables == null && fitnessVariables == null && healthVariables == null && profileVariables == null

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -10,15 +10,17 @@ module.exports = async function (context) {
 
     const configXML = path.join(projectRoot, 'config.xml');
     const configParser = new ConfigParser(configXML);
+
+    const parser = new DOMParser();
         
     // add health connect permissions to AndroidManifest.xml and health_permissions.xml files
-    addHealthConnectPermissionsToXmlFiles(configParser, projectRoot);
+    addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser);
 
     // add background job permissions to AndroidManfiest.xml
-    addBackgroundJobPermissionsToManifest(configParser, projectRoot);
+    addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser);
 };
 
-function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot) {
+function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser) {
 
     // Permission groups
     const fitnessPermissionsRead = [
@@ -102,8 +104,6 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot) {
     var bmrSet = false
     var speedSet = false
     var distanceSet = false
-
-    const parser = new DOMParser();
 
     // Android >= 14 dependencies should be included directly in the AndroidManifest.xml file
     // Read the AndroidManifest.xml file
@@ -1120,7 +1120,7 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot) {
 
 }
 
-function addBackgroundJobPermissionsToManifest(configParser, projectRoot) {
+function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser) {
 
     const disableBackgroundJobs = configParser.getPlatformPreference('DisableBackgroundJobs', 'android');
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -140,7 +140,7 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         arrayElement.appendChild(newItem);
         */
 
-        addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, 'android.permission.health.READ_HEART_RATE');
+        addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE');
     }
 
     if (heartRate == "ReadWrite" || heartRate == "Write") {
@@ -1127,7 +1127,7 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 
 }
 
-function addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, permission) {
+function addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, arrayElement, permission) {
 
     console.log("entered addEntryToManifestAndPermissionsXml");
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -101,27 +101,18 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
 
 
-    // Android >= 14 dependencies, which should be included directly in the AndroidManifest.xml file
-
-    console.log('About to read the AndroidManifest.xml file');
+    // Android >= 14 dependencies should be included directly in the AndroidManifest.xml file
+    // Android <= 13 dependencies should be included in a separate XML file
 
     // Read the AndroidManifest.xml file
     const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
     const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');
 
-    console.log('About to parse the XML string');
 
     // Parse the XML string
     const parser = new DOMParser();
     const manifestXmlDoc = parser.parseFromString(manifestXmlString, 'text/xml');
-
-    console.log('About to append permission');
-
-    /*
-    const newPermission = manifestXmlDoc.createElement('uses-permission');
-    newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
-    manifestXmlDoc.documentElement.appendChild(newPermission);
-    */
+ 
 
     // heartRate
     if (heartRate == "ReadWrite" || heartRate == "Read") {

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1171,12 +1171,12 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
-    const titleElement = stringsXmlDoc.querySelector(`string[name="background_notification_title"]`);
+    const titleElement = stringsXmlDoc.getElementById('background_notification_title');
     if (titleElement) {
         titleElement.textContent = notificationTitle;
     }
 
-    const descriptionElement = stringsXmlDoc.querySelector(`string[name="background_notification_description"]`);
+    const descriptionElement = stringsXmlDoc.getElementById('background_notification_description');
     if (descriptionElement) {
         descriptionElement.textContent = notificationDescription;
     }

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -19,79 +19,79 @@ let permissions = {
         wasSet: false
     },
     Steps: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "Steps",
+        readPermission: "android.permission.health.READ_STEPS",
+        writePermission: "android.permission.health.WRITE_STEPS",
         configValue: undefined,
         wasSet: false
     },
     Weight: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "Weight",
+        readPermission: "android.permission.health.READ_WEIGHT",
+        writePermission: "android.permission.health.WRITE_WEIGHT",
         configValue: undefined,
         wasSet: false
     },
     Height: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "Height",
+        readPermission: "android.permission.health.READ_HEIGHT",
+        writePermission: "android.permission.health.WRITE_HEIGHT",
         configValue: undefined,
         wasSet: false
     },
     CaloriesBurned: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "CaloriesBurned",
+        readPermission: "android.permission.health.READ_TOTAL_CALORIES_BURNED",
+        writePermission: "android.permission.health.WRITE_TOTAL_CALORIES_BURNED",
         configValue: undefined,
         wasSet: false
     },
     Sleep: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "Sleep",
+        readPermission: "android.permission.health.READ_SLEEP",
+        writePermission: "android.permission.health.WRITE_SLEEP",
         configValue: undefined,
         wasSet: false
     },
     BloodPressure: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "BloodPressure",
+        readPermission: "android.permission.health.READ_BLOOD_PRESSURE",
+        writePermission: "android.permission.health.WRITE_BLOOD_PRESSURE",
         configValue: undefined,
         wasSet: false
     },
     BloodGlucose: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "BloodGlucose",
+        readPermission: "android.permission.health.READ_BLOOD_GLUCOSE",
+        writePermission: "android.permission.health.WRITE_BLOOD_GLUCOSE",
         configValue: undefined,
         wasSet: false
     },
     BodyFatPercentage: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "BodyFatPercentage",
+        readPermission: "android.permission.health.READ_BODY_FAT",
+        writePermission: "android.permission.health.WRITE_BODY_FAT",
         configValue: undefined,
         wasSet: false
     },
     BasalMetabolicRate: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "BasalMetabolicRate",
+        readPermission: "android.permission.health.READ_BASAL_METABOLIC_RATE",
+        writePermission: "android.permission.health.WRITE_BASAL_METABOLIC_RATE",
         configValue: undefined,
         wasSet: false
     },
     WalkingSpeed: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "WalkingSpeed",
+        readPermission: "android.permission.health.READ_SPEED",
+        writePermission: "android.permission.health.WRITE_SPEED",
         configValue: undefined,
         wasSet: false
     },
     Distance: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "Distance",
+        readPermission: "android.permission.health.READ_DISTANCE",
+        writePermission: "android.permission.health.WRITE_DISTANCE",
         configValue: undefined,
         wasSet: false
     }
@@ -99,17 +99,13 @@ let permissions = {
 
 let groupPermissions = {
     AllVariables: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "AllVariables",
         configValue: undefined,
         wasSet: false,
         groupVariables: []
     },
     FitnessVariables: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "FitnessVariables",
         configValue: undefined,
         // we'll use these to know if we should set individual permissions or not
         // e.g. when checking HeartRate, if all healthVariables were already set, we don't need to add it again
@@ -117,20 +113,16 @@ let groupPermissions = {
         groupVariables: ["Steps", "CaloriesBurned", "WalkingSpeed", "Distance"]
     },
     HealthVariables: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "HealthVariables",
         configValue: undefined,
         wasSet: false,
-        groupVariables: ["Steps", "CaloriesBurned", "WalkingSpeed", "Distance"]
+        groupVariables: ["HeartRate", "Sleep", "BloodPressure", "BloodGlucose"]
     },
     ProfileVariables: {
-        variableName: "HeartRate",
-        readPermission: "android.permission.health.READ_HEART_RATE",
-        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        variableName: "ProfileVariables",
         configValue: undefined,
         wasSet: false,
-        groupVariables: ["Steps", "CaloriesBurned", "WalkingSpeed", "Distance"]
+        groupVariables: ["Weight", "Height", "BodyFatPercentage", "BasalMetabolicRate"]
     }
 }
 
@@ -154,13 +146,13 @@ module.exports = async function (context) {
 
 function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser) {
 
-    permissions.map((p) => {
-        p.configValue = configParser.getPlatformPreference(p.variableName, 'android');
-    })
+    for(const key in permissions){
+        permissions[key].configValue = configParser.getPlatformPreference(permissions[key].variableName, 'android');
+    }
 
-    groupPermissions.map((p) => {
-        p.configValue = configParser.getPlatformPreference(p.variableName, 'android');
-    })
+    for(const key in groupPermissions){
+        groupPermissions[key].configValue = configParser.getPlatformPreference(groupPermissions[key].variableName, 'android');
+    }
 
     // Android >= 14 dependencies should be included directly in the AndroidManifest.xml file
     // Read the AndroidManifest.xml file
@@ -178,7 +170,8 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
  
 
     // process each individual variable
-    Object.entries(permissions).forEach( p => {
+    for(const key in permissions){
+        let p = permissions[key]
         if (p.configValue == READWRITE || p.configValue == READ) {
             p.wasSet = true;
             processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.readPermission)
@@ -187,11 +180,12 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
             p.wasSet = true;
             processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.writePermission)
         }
-    })
+    }
 
 
     // process group variables
-    Object.entries(groupPermissions).forEach( p => {
+    for(const key in groupPermissions){
+        let p = groupPermissions[key]
         if (p.configValue == READWRITE || p.configValue == READ) {
             p.wasSet = true;
             p.groupVariables.forEach( v => {
@@ -208,41 +202,27 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
                 }
             })
         }
-    })
+    }
 
-    // process AllVariables
-    Object.entries(groupPermissions).forEach( p => {
-        p.groupVariables.forEach( v => {
-            if (allVariables == READWRITE || allVariables == READ) {
-                if (!p.wasSet && !permissions[v].wasSet) {
-                    processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissions[v].readPermission)
-                }
-            }
-            if ((allVariables == READWRITE || allVariables == WRITE)) {
-                if (!p.wasSet && !permissions[v].wasSet) {
-                    processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissions[v].writePermission)
-                }
-            }
-
-            
-        })
-    })
+    let permissionValues = Object.values(permissions)
+    let groupPermissionValues = Object.values(groupPermissions)
 
     // process AllVariables
     if (groupPermissions.AllVariables.configValue == READWRITE || groupPermissions.AllVariables.configValue == READ) {   
-        processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, READ)
+        processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, READ, groupPermissionValues)
 
     }
 
     if ((groupPermissions.AllVariables.configValue == READWRITE || groupPermissions.AllVariables.configValue == WRITE)) {  
-        processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, WRITE)
+        processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, WRITE, groupPermissionValues)
     }
     
+    let numberOfPermissions = permissionValues.filter(p => p.configValue != "").length + groupPermissionValues.filter(p => p.configValue != "").length
 
-    let numberOfPermissions = permissions.filter(p => p.configValue != "").length + groupPermissions.filter(p => p.configValue != "").length
     // if there is no AllVariables nor anything else, then by default we add all the permissions
+
     if (numberOfPermissions == 0) {
-        Object.entries(permissions).forEach( p => {
+        permissionValues.forEach( p => {
             processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.readPermission)
             processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.writePermission)
         })
@@ -264,8 +244,8 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 
 }
 
-function processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissionOperation) {
-    Object.entries(groupPermissions).forEach(p => {
+function processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissionOperation, groupPermissionsValues) {
+    groupPermissionsValues.forEach(p => {
         p.groupVariables.forEach( v => {
             if (!p.wasSet && !permissions[v].wasSet) {
                 processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissionOperation == READ ? permissions[v].readPermission : permissions[v].writePermission)

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1161,9 +1161,6 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     const notificationTitle = configParser.getPlatformPreference('BackgroundNotificationTitle', 'android');
     const notificationDescription = configParser.getPlatformPreference('BackgroundNotificationDescription', 'android');
 
-    console.log('BackgroundNotificationTitle: ' + notificationTitle);
-    console.log('BackgroundNotificationDescription: ' + notificationDescription);
-
     // we only want a default value for the title
     if (notificationTitle == "") {
         notificationTitle = "Measuring your health and fitness data."
@@ -1173,31 +1170,9 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     const stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
-
-    console.log('strings.xml: ' + stringsXmlString);
-
-    stringsXmlDoc.getElementsByTagName
-
-    /*
-
-    const titleElement = stringsXmlDoc.getElementById('background_notification_title');
-    console.log('titleElement: ' + titleElement);
-    if (titleElement) {
-        console.log('Setting Title');
-        titleElement.textContent = notificationTitle;
-    }
-
-    const descriptionElement = stringsXmlDoc.getElementById('background_notification_description');
-    console.log('descriptionElement: ' + descriptionElement);
-    if (descriptionElement) {
-        console.log('Setting Description');
-        descriptionElement.textContent = notificationDescription;
-    }
-    */
-
     const stringElements = stringsXmlDoc.getElementsByTagName('string');
 
-    // Set text for each <string> element
+    // set text for each <string> element
     for (let i = 0; i < stringElements.length; i++) {
         const name = stringElements[i].getAttribute('name');
         if (name == "background_notification_title") {

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -10,12 +10,8 @@ module.exports = async function (context) {
 
     const configXML = path.join(projectRoot, 'config.xml');
     const configParser = new ConfigParser(configXML);
-
-    console.log('About to call addPermissionsToManfiest');
         
     addPermissionsToManifest(configParser, projectRoot);
-
-
 };
 
 function addPermissionsToManifest(configParser, projectRoot) {
@@ -719,13 +715,9 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
         }
 
-    console.log('About to serialize');
-
     // Serialize the updated XML document back to string
     const serializer = new XMLSerializer();
     const updatedManifestXmlString = serializer.serializeToString(manifestXmlDoc);
-
-    console.log('About to write the file again');
 
     // Write the updated XML string back to the same file
     fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -18,6 +18,7 @@ module.exports = async function (context) {
 
     // add background job permissions to AndroidManfiest.xml
     addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser);
+
 };
 
 function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser) {
@@ -1123,9 +1124,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser) {
 
     const disableBackgroundJobs = configParser.getPlatformPreference('DisableBackgroundJobs', 'android');
-    
+
+    console.log('disableBackgroundJobs: ' + disableBackgroundJobs);
+
+    if (disableBackgroundJobs === false) {
+        console.log('first');
+    }
+
+    if (disableBackgroundJobs == "false") {
+        console.log('second');
+    }
+
+    if (disableBackgroundJobs === "false") {
+        console.log('third');
+    }
+
     // we want to include the permissions by default
-    if (disableBackgroundJobs == false || disableBackgroundJobs == "") {
+    if (disableBackgroundJobs === false || disableBackgroundJobs == "") {
 
         const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
         const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1178,7 +1178,7 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     }
 
     if (notificationDescription == "") {
-        notificationDescription = "The app is running on the background."
+        notificationDescription = "The app is running in the background."
     }
 
     // insert values in strings.xml

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1128,6 +1128,7 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
     const disableBackgroundJobs = configParser.getPlatformPreference('DisableBackgroundJobs', 'android');
 
     // we want to include the permissions by default
+    // if disableBackgroundJobs == true then we don't want to include the permissions in the manfiest
     if (disableBackgroundJobs !== "true") {
 
         const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
@@ -1136,7 +1137,6 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
         // Parse the XML string
         const manifestXmlDoc = parser.parseFromString(manifestXmlString, 'text/xml');
 
-        // if disableBackgroundJobs == true then we don't want to include the permissions in the manfiest
         const notificationsPermission = manifestXmlDoc.createElement('uses-permission');
         notificationsPermission.setAttribute('android:name', 'android.permission.POST_NOTIFICATIONS');
         manifestXmlDoc.documentElement.appendChild(notificationsPermission);
@@ -1144,6 +1144,18 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
         const activityPermission = manifestXmlDoc.createElement('uses-permission');
         activityPermission.setAttribute('android:name', 'android.permission.ACTIVITY_RECOGNITION');
         manifestXmlDoc.documentElement.appendChild(activityPermission);
+
+        const foregroundServicePermission = manifestXmlDoc.createElement('uses-permission');
+        foregroundServicePermission.setAttribute('android:name', 'android.permission.FOREGROUND_SERVICE');
+        manifestXmlDoc.documentElement.appendChild(foregroundServicePermission);
+
+        const foregroundServiceHealthPermission = manifestXmlDoc.createElement('uses-permission');
+        foregroundServiceHealthPermission.setAttribute('android:name', 'android.permission.FOREGROUND_SERVICE_HEALTH');
+        manifestXmlDoc.documentElement.appendChild(foregroundServiceHealthPermission);
+
+        const highSamplingPermission = manifestXmlDoc.createElement('uses-permission');
+        highSamplingPermission.setAttribute('android:name', 'android.permission.HIGH_SAMPLING_RATE_SENSORS');
+        manifestXmlDoc.documentElement.appendChild(highSamplingPermission);
 
         // serialize the updated XML document back to string
         const serializer = new XMLSerializer();

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const { ConfigParser } = require('cordova-common');
+const et = require('elementtree');
+const { DOMParser, XMLSerializer } = require('xmldom');
+
+module.exports = async function (context) {
+    const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+
+    const configXML = path.join(projectRoot, 'config.xml');
+    const configParser = new ConfigParser(configXML);
+
+    console.log('About to call addPermissionsToManfiest');
+        
+    addPermissionsToManifest(configParser, projectRoot);
+
+
+};
+
+function addPermissionsToManifest(configParser, projectRoot) {
+
+    //get all the preferences from config.xml, for every Health Connect permission
+    const allVariables = configParser.getPlatformPreference('AllVariables', 'android');
+    const fitnessVariables = configParser.getPlatformPreference('FitnessVariables', 'android');
+    const healthVariables = configParser.getPlatformPreference('HealthVariables', 'android');
+    const profileVariables = configParser.getPlatformPreference('ProfileVariables', 'android');
+
+    console.log('About to read the AndroidManifest.xml file');
+
+    // Read the AndroidManifest.xml file
+    const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
+    const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');
+
+    console.log('About to parse the XML string');
+
+    // Parse the XML string
+    const parser = new DOMParser();
+    const manifestXmlDoc = parser.parseFromString(manifestXmlString, 'text/xml');
+
+    console.log('About to append permission');
+
+    const newPermission = manifestXmlDoc.createElement('uses-permission');
+    newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
+    manifestXmlDoc.documentElement.appendChild(newPermission);
+
+    console.log('About to serialize');
+
+    // Serialize the updated XML document back to string
+    const serializer = new XMLSerializer();
+    const updatedManifestXmlString = serializer.serializeToString(manifestXmlDoc);
+
+    console.log('About to write the file again');
+
+    // Write the updated XML string back to the same file
+    fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');
+
+    /*
+
+    if (allVariables == "true") {
+        // in this case, we don't look for any other preferences
+        // add all the permissions for all the variables we have
+        
+    } else if (fitnessVariables == "true") {
+        // add all permissions for fitness variables
+
+    } else if (healthVariables == "true") {
+        // add all permissions for health variables
+
+    } else if (profileVariables == "true") {
+        // add all permissions for profile variables
+
+    } else {
+        // look for every variable individually and add the permission for it if its value is true
+
+    }
+
+    */
+
+    // for every permission that is present in the config.xml file, we add it to the AndroidManifest.xml file
+
+    // finally, we save the file by doing the following
+    
+    /*
+    let resultXmlStrings = etreeStrings.write();
+    fs.writeFileSync(stringsPath, resultXmlStrings);
+    */
+
+
+}

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -677,7 +677,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
     console.log('allVariables: ' + allVariables);
 
-    if (allVariables === undefined) {
+    if (allVariables == "") {
         console.log('allVariables is undefined');
     }
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1171,12 +1171,12 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
-    const titleElement = stringsXmlDoc.querySelector(`string[name="${background_notification_title}"]`);
+    const titleElement = stringsXmlDoc.querySelector(`string[name="background_notification_title"]`);
     if (titleElement) {
         titleElement.textContent = notificationTitle;
     }
 
-    const descriptionElement = stringsXmlDoc.querySelector(`string[name="${background_notification_description}"]`);
+    const descriptionElement = stringsXmlDoc.querySelector(`string[name="background_notification_description"]`);
     if (descriptionElement) {
         descriptionElement.textContent = notificationDescription;
     }

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1158,7 +1158,7 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
 function copyNotificationContent(configParser, projectRoot, parser) {
 
     // get values from config.xml
-    const notificationTitle = configParser.getPlatformPreference('BackgroundNotificationTitle', 'android');
+    var notificationTitle = configParser.getPlatformPreference('BackgroundNotificationTitle', 'android');
     const notificationDescription = configParser.getPlatformPreference('BackgroundNotificationDescription', 'android');
 
     // we only want a default value for the title
@@ -1176,11 +1176,9 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     for (let i = 0; i < stringElements.length; i++) {
         const name = stringElements[i].getAttribute('name');
         if (name == "background_notification_title") {
-            console.log('Setting Title');
             stringElements[i].textContent = notificationTitle;
         }
         else if (name == "background_notification_description") {
-            console.log('Setting Description');
             stringElements[i].textContent = notificationDescription;
         }
     }

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -140,7 +140,7 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         arrayElement.appendChild(newItem);
         */
 
-        addEntryToManifestAndPermissionsXml('android.permission.health.READ_HEART_RATE');
+        addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, 'android.permission.health.READ_HEART_RATE');
     }
 
     if (heartRate == "ReadWrite" || heartRate == "Write") {
@@ -1127,7 +1127,7 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 
 }
 
-function addEntryToManifestAndPermissionsXml(permission) {
+function addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, permission) {
 
     console.log("entered addEntryToManifestAndPermissionsXml");
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1174,6 +1174,8 @@ function copyNotificationContent(configParser, projectRoot, parser) {
     const stringsXmlString = fs.readFileSync(stringsXmlPath, 'utf-8');
     const stringsXmlDoc = parser.parseFromString(stringsXmlString, 'text/xml')
 
+    console.log('strings.xml: ' + stringsXmlString);
+
     const titleElement = stringsXmlDoc.getElementById('background_notification_title');
     if (titleElement) {
         console.log('Setting Title');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -677,10 +677,10 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
 
     // if there is no AllVariables nor anything else, then by default we add all the permissions
-    if (allVariables == null && fitnessVariables == null && healthVariables === null && profileVariables === null
-        && heartRate === null && steps === null && weight === null && height === null
-        && calories === null && sleep === null && bloodPressure === null && bloodGlucose === null
-        && bodyFat === null && bmr === null && speed == null && distance == null) {
+    if (allVariables == null && fitnessVariables == null && healthVariables == null && profileVariables == null
+        && heartRate == null && steps == null && weight == null && height == null
+        && calories == null && sleep == null && bloodPressure == null && bloodGlucose == null
+        && bodyFat == null && bmr == null && speed == null && distance == null) {
 
             fitnessPermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -16,7 +16,7 @@ module.exports = async function (context) {
     // add health connect permissions to AndroidManifest.xml and health_permissions.xml files
     addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser);
 
-    // add background job permissions to AndroidManfiest.xml
+    // add background job permissions to AndroidManifest.xml
     addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser);
 
     // copy notification title and content for notificaiton for Foreground Service

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -5,6 +5,135 @@ const et = require('elementtree');
 const { DOMParser, XMLSerializer } = require('xmldom');
 const { captureRejectionSymbol } = require('events');
 
+const READ = "Read"
+const WRITE = "Write"
+const READWRITE = "ReadWrite"
+
+let permissions = {
+    HeartRate: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        // we'll use these to know if we should write group permissions or not
+        wasSet: false
+    },
+    Steps: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    Weight: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    Height: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    CaloriesBurned: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    Sleep: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    BloodPressure: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    BloodGlucose: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    BodyFatPercentage: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    BasalMetabolicRate: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    WalkingSpeed: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    },
+    Distance: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false
+    }
+}
+
+let groupPermissions = {
+    AllVariables: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false,
+        groupVariables: []
+    },
+    FitnessVariables: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        // we'll use these to know if we should set individual permissions or not
+        // e.g. when checking HeartRate, if all healthVariables were already set, we don't need to add it again
+        wasSet: false,
+        groupVariables: ["Steps", "CaloriesBurned", "WalkingSpeed", "Distance"]
+    },
+    HealthVariables: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false,
+        groupVariables: ["Steps", "CaloriesBurned", "WalkingSpeed", "Distance"]
+    },
+    ProfileVariables: {
+        variableName: "HeartRate",
+        readPermission: "android.permission.health.READ_HEART_RATE",
+        writePermission: "android.permission.health.WRITE_HEART_RATE",
+        configValue: undefined,
+        wasSet: false,
+        groupVariables: ["Steps", "CaloriesBurned", "WalkingSpeed", "Distance"]
+    }
+}
+
 module.exports = async function (context) {
     const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
 
@@ -25,88 +154,13 @@ module.exports = async function (context) {
 
 function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser) {
 
-    // Permission groups
-    const fitnessPermissionsRead = [
-        { name: 'android.permission.health.READ_STEPS' },
-        { name: 'android.permission.health.READ_TOTAL_CALORIES_BURNED' },
-        { name: 'android.permission.health.READ_SPEED' },
-        { name: 'android.permission.health.READ_DISTANCE' }
-    ];
+    permissions.map((p) => {
+        p.configValue = configParser.getPlatformPreference(p.variableName, 'android');
+    })
 
-    const fitnessPermissionsWrite = [
-        { name: 'android.permission.health.WRITE_STEPS' },
-        { name: 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED' },
-        { name: 'android.permission.health.WRITE_SPEED' },
-        { name: 'android.permission.health.WRITE_DISTANCE' }
-    ];
-
-    const healthPermissionsRead = [
-        { name: 'android.permission.health.READ_HEART_RATE' },
-        { name: 'android.permission.health.READ_SLEEP' },
-        { name: 'android.permission.health.READ_BLOOD_PRESSURE' },
-        { name: 'android.permission.health.READ_BLOOD_GLUCOSE' }
-    ];
-
-    const healthPermissionsWrite = [
-        { name: 'android.permission.health.WRITE_HEART_RATE' },
-        { name: 'android.permission.health.WRITE_SLEEP' },
-        { name: 'android.permission.health.WRITE_BLOOD_PRESSURE' },
-        { name: 'android.permission.health.WRITE_BLOOD_GLUCOSE' }
-    ];
-
-    const profilePermissionsRead = [
-        { name: 'android.permission.health.READ_WEIGHT' },
-        { name: 'android.permission.health.READ_HEIGHT' },
-        { name: 'android.permission.health.READ_BODY_FAT' },
-        { name: 'android.permission.health.READ_BASAL_METABOLIC_RATE' }
-    ];
-
-    const profilePermissionsWrite = [
-        { name: 'android.permission.health.WRITE_WEIGHT' },
-        { name: 'android.permission.health.WRITE_HEIGHT' },
-        { name: 'android.permission.health.WRITE_BODY_FAT' },
-        { name: 'android.permission.health.WRITE_BASAL_METABOLIC_RATE' }
-    ];
-
-    //get all the preferences from config.xml, for every Health Connect permission
-    const allVariables = configParser.getPlatformPreference('AllVariables', 'android');
-    const fitnessVariables = configParser.getPlatformPreference('FitnessVariables', 'android');
-    const healthVariables = configParser.getPlatformPreference('HealthVariables', 'android');
-    const profileVariables = configParser.getPlatformPreference('ProfileVariables', 'android');
-
-    // individual variables
-    const heartRate = configParser.getPlatformPreference('HeartRate', 'android');
-    const steps = configParser.getPlatformPreference('Steps', 'android');
-    const weight = configParser.getPlatformPreference('Weight', 'android');
-    const height = configParser.getPlatformPreference('Height', 'android');
-    const calories = configParser.getPlatformPreference('CaloriesBurned', 'android');
-    const sleep = configParser.getPlatformPreference('Sleep', 'android');
-    const bloodPressure = configParser.getPlatformPreference('BloodPressure', 'android');
-    const bloodGlucose = configParser.getPlatformPreference('BloodGlucose', 'android');
-    const bodyFat = configParser.getPlatformPreference('BodyFatPercentage', 'android');
-    const bmr = configParser.getPlatformPreference('BasalMetabolicRate', 'android');
-    const speed = configParser.getPlatformPreference('WalkingSpeed', 'android');
-    const distance = configParser.getPlatformPreference('Distance', 'android');
-
-    // we'll use these to know if we should set individual permissions or not
-    // e.g. when checking HeartRate, if all healthVariables were already set, we don't need to add it again
-    var fitnessSet = false
-    var healthSet = false
-    var profileSet = false
-
-    // we'll use these to know if we should write group permissions or not
-    var heartRateSet = false
-    var stepsSet = false
-    var weightSet = false
-    var heightSet = false
-    var caloriesSet = false
-    var sleepSet = false
-    var bloodPressureSet = false
-    var bloodGlucoseSet = false
-    var bodyFatSet = false
-    var bmrSet = false
-    var speedSet = false
-    var distanceSet = false
+    groupPermissions.map((p) => {
+        p.configValue = configParser.getPlatformPreference(p.variableName, 'android');
+    })
 
     // Android >= 14 dependencies should be included directly in the AndroidManifest.xml file
     // Read the AndroidManifest.xml file
@@ -123,495 +177,76 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
     const arrayElement = permissionsXmlDoc.getElementsByTagName('array')[0];
  
 
-    // heartRate
-    if (heartRate == "ReadWrite" || heartRate == "Read") {
-        heartRateSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEART_RATE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE')
-    }
-
-    if (heartRate == "ReadWrite" || heartRate == "Write") {
-        heartRateSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEART_RATE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEART_RATE')
-    }
-
-    // steps
-    if (steps == "ReadWrite" || steps == "Read") {
-        stepsSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_STEPS')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_STEPS')
-    }
-
-    if (steps == "ReadWrite" || steps == "Write") {
-        stepsSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_STEPS')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_STEPS')
-    }
-
-    // weight
-    if (weight == "ReadWrite" || weight == "Read") {
-        weightSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_WEIGHT')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_WEIGHT')
-    }
-
-    if (weight == "ReadWrite" || weight == "Write") {
-        weightSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_WEIGHT')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_WEIGHT')
-    }
-
-    // height
-    if (height == "ReadWrite" || height == "Read") {
-        heightSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEIGHT')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEIGHT')
-    }
-
-    if (height == "ReadWrite" || height == "Write") {
-        heightSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEIGHT')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEIGHT')
-    }
-
-    // calories
-    if (calories == "ReadWrite" || calories == "Read") {
-        caloriesSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
-    }
-
-    if (calories == "ReadWrite" || calories == "Write") {
-        caloriesSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
-    }
-
-    // sleep
-    if (sleep == "ReadWrite" || sleep == "Read") {
-        sleepSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SLEEP')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SLEEP')
-    }
-
-    if (sleep == "ReadWrite" || sleep == "Write") {
-        sleepSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SLEEP')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SLEEP')
-    }
-
-    // blood pressure
-    if (bloodPressure == "ReadWrite" || bloodPressure == "Read") {
-        bloodPressureSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_PRESSURE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_PRESSURE')
-    }
-
-    if (bloodPressure == "ReadWrite" || bloodPressure == "Write") {
-        bloodPressureSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_PRESSURE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_PRESSURE')
-    }
-
-    // blood glucose
-    if (bloodGlucose == "ReadWrite" || bloodGlucose == "Read") {
-        bloodGlucoseSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_GLUCOSE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_GLUCOSE')
-    }
-
-    if (bloodGlucose == "ReadWrite" || bloodGlucose == "Write") {
-        bloodGlucoseSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
-    }
-
-    // body fat
-    if (bodyFat == "ReadWrite" || bodyFat == "Read") {
-        bodyFatSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BODY_FAT')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BODY_FAT')
-    }
-
-    if (bodyFat == "ReadWrite" || bodyFat == "Write") {
-        bodyFatSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BODY_FAT')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BODY_FAT')
-    }
-
-    // bmr
-    if (bmr == "ReadWrite" || bmr == "Read") {
-        bmrSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
-    }
-
-    if (bmr == "ReadWrite" || bmr == "Write") {
-        bmrSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
-    }
-
-    // speed
-    if (speed == "ReadWrite" || speed == "Read") {
-        speedSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SPEED')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SPEED')
-    }
-
-    if (speed == "ReadWrite" || speed == "Write") {
-        speedSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SPEED')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SPEED')
-    }
-
-    // distance
-    if (distance == "ReadWrite" || distance == "Read") {
-        distanceSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_DISTANCE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_DISTANCE')
-    }
-
-    if (distance == "ReadWrite" || distance == "Write") {
-        distanceSet = true
-        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_DISTANCE')
-        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_DISTANCE')
-    }
-
-    // process fitness variables
-    if (fitnessVariables == "ReadWrite" || fitnessVariables == "Read") {
-
-        fitnessSet = true
-
-        if (!stepsSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_STEPS')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_STEPS')
+    // process each individual variable
+    Object.entries(permissions).forEach( p => {
+        if (p.configValue == READWRITE || p.configValue == READ) {
+            p.wasSet = true;
+            processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.readPermission)
         }
-
-        if (!caloriesSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
+        if (p.configValue == READWRITE || p.configValue == WRITE) {
+            p.wasSet = true;
+            processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.writePermission)
         }
+    })
 
-        if (!speedSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SPEED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SPEED')
+
+    // process group variables
+    Object.entries(groupPermissions).forEach( p => {
+        if (p.configValue == READWRITE || p.configValue == READ) {
+            p.wasSet = true;
+            p.groupVariables.forEach( v => {
+                if (!permissions[v].wasSet) {
+                    processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissions[v].readPermission)
+                }
+            })
         }
-
-        if (!distanceSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_DISTANCE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_DISTANCE')
+        if (p.configValue == READWRITE || p.configValue == WRITE) {
+            p.wasSet = true;
+            p.groupVariables.forEach( v => {
+                if (!permissions[v].wasSet) {
+                    processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissions[v].writePermission)
+                }
+            })
         }
-
-    }
-
-    if (fitnessVariables == "ReadWrite" || fitnessVariables == "Write") {
-
-        fitnessSet = true
-
-        if (!stepsSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_STEPS')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_STEPS')
-        }
-
-        if (!caloriesSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
-        }
-
-        if (!speedSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SPEED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SPEED')
-        }
-
-        if (!distanceSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_DISTANCE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_DISTANCE')
-        }
-
-    }
-
-    // process health variables
-    if (healthVariables == "ReadWrite" || healthVariables == "Read") {
-
-        healthSet = true
-
-        if (!heartRateSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEART_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE')
-        }
-
-        if (!sleepSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SLEEP')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SLEEP')
-        }
-
-        if (!bloodPressureSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_PRESSURE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_PRESSURE')
-        }
-
-        if (!bloodGlucoseSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_GLUCOSE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_GLUCOSE')
-        }
-
-    }
-
-    if (healthVariables == "ReadWrite" || healthVariables == "Write") {
-
-        healthSet = true
-
-        if (!heartRateSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEART_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEART_RATE')
-        }
-
-        if (!sleepSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SLEEP')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SLEEP')
-        }
-
-        if (!bloodPressureSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_PRESSURE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_PRESSURE')
-        }
-
-        if (!bloodGlucoseSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
-        }
-
-    }
-
-    // process profile variables
-    if (profileVariables == "ReadWrite" || profileVariables == "Read") {
-
-        profileSet = true
-
-        if (!weightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_WEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_WEIGHT')
-        }
-
-        if (!heightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEIGHT')
-        }
-
-        if (!bodyFatSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BODY_FAT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BODY_FAT')
-        }
-
-        if (!bmrSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
-        }
-
-    }
-
-    if (profileVariables == "ReadWrite" || profileVariables == "Write") {
-
-        profileSet = true
-
-        if (!weightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_WEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_WEIGHT')
-        }
-
-        if (!heightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEIGHT')
-        }
-
-        if (!bodyFatSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BODY_FAT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BODY_FAT')
-        }
-
-        if (!bmrSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
-        }
-
-    }
-
+    })
 
     // process AllVariables
+    Object.entries(groupPermissions).forEach( p => {
+        p.groupVariables.forEach( v => {
+            if (allVariables == READWRITE || allVariables == READ) {
+                if (!p.wasSet && !permissions[v].wasSet) {
+                    processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissions[v].readPermission)
+                }
+            }
+            if ((allVariables == READWRITE || allVariables == WRITE)) {
+                if (!p.wasSet && !permissions[v].wasSet) {
+                    processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissions[v].writePermission)
+                }
+            }
 
-    if (allVariables == "ReadWrite" || allVariables == "Read") {
+            
+        })
+    })
 
-        // fitness
-        if (!fitnessSet && !stepsSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_STEPS')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_STEPS')
-        }
+    // process AllVariables
+    if (groupPermissions.AllVariables.configValue == READWRITE || groupPermissions.AllVariables.configValue == READ) {   
+        processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, READ)
 
-        if (!fitnessSet && !caloriesSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
-        }
-
-        if (!fitnessSet && !speedSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SPEED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SPEED')
-        }
-
-        if (!fitnessSet && !distanceSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_DISTANCE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_DISTANCE')
-        }
-
-        // health
-        if (!healthSet && !heartRateSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEART_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE')
-        }
-
-        if (!healthSet && !sleepSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SLEEP')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SLEEP')
-        }
-
-        if (!healthSet && !bloodPressureSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_PRESSURE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_PRESSURE')
-        }
-
-        if (!healthSet && !bloodGlucoseSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_GLUCOSE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_GLUCOSE')
-        }
-
-        // profile
-        if (!profileSet && !weightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_WEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_WEIGHT')
-        }
-
-        if (!profileSet && !heightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEIGHT')
-        }
-
-        if (!profileSet && !bodyFatSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BODY_FAT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BODY_FAT')
-        }
-
-        if (!profileSet && !bmrSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
-        }
-        
     }
 
-    if (allVariables == "ReadWrite" || allVariables == "Write") {
-
-        // fitness
-        if (!fitnessSet && !stepsSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_STEPS')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_STEPS')
-        }
-
-        if (!fitnessSet && !caloriesSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
-        }
-
-        if (!fitnessSet && !speedSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SPEED')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SPEED')
-        }
-
-        if (!fitnessSet && !distanceSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_DISTANCE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_DISTANCE')
-        }
-
-        // health
-        if (!healthSet && !heartRateSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEART_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEART_RATE')
-        }
-
-        if (!healthSet && !sleepSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SLEEP')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SLEEP')
-        }
-
-        if (!healthSet && !bloodPressureSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_PRESSURE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_PRESSURE')
-        }
-
-        if (!healthSet && !bloodGlucoseSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
-        }
-
-        // profile
-        if (!profileSet && !weightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_WEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_WEIGHT')
-        }
-
-        if (!profileSet && !heightSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEIGHT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEIGHT')
-        }
-
-        if (!profileSet && !bodyFatSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BODY_FAT')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BODY_FAT')
-        }
-
-        if (!profileSet && !bmrSet) {
-            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
-            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
-        }
-        
+    if ((groupPermissions.AllVariables.configValue == READWRITE || groupPermissions.AllVariables.configValue == WRITE)) {  
+        processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, WRITE)
     }
+    
 
+    let numberOfPermissions = permissions.filter(p => p.configValue != "").length + groupPermissions.filter(p => p.configValue != "").length
     // if there is no AllVariables nor anything else, then by default we add all the permissions
-    if (allVariables == "" && fitnessVariables == "" && healthVariables == "" && profileVariables == ""
-        && heartRate == "" && steps == "" && weight == "" && height == ""
-        && calories == "" && sleep == "" && bloodPressure == "" && bloodGlucose == ""
-        && bodyFat == "" && bmr == "" && speed == "" && distance == "") {
-
-            fitnessPermissionsRead.forEach(permission => {
-                addEntryToManifest(manifestXmlDoc, permission.name)
-                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
-            });
-            
-            fitnessPermissionsWrite.forEach(permission => {
-                addEntryToManifest(manifestXmlDoc, permission.name)
-                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
-            });
-    
-            healthPermissionsRead.forEach(permission => {
-                addEntryToManifest(manifestXmlDoc, permission.name)
-                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
-            });
-            
-            healthPermissionsWrite.forEach(permission => {
-                addEntryToManifest(manifestXmlDoc, permission.name)
-                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
-            });
-    
-            profilePermissionsRead.forEach(permission => {
-                addEntryToManifest(manifestXmlDoc, permission.name)
-                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
-            });
-            
-            profilePermissionsWrite.forEach(permission => {
-                addEntryToManifest(manifestXmlDoc, permission.name)
-                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
-            });
-
-        }
+    if (numberOfPermissions == 0) {
+        Object.entries(permissions).forEach( p => {
+            processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.readPermission)
+            processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, p.writePermission)
+        })
+    }
 
     // Serialize the updated XML document back to string
     const serializer = new XMLSerializer();
@@ -627,6 +262,21 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
     // Write the updated XML string back to the same file
     fs.writeFileSync(permissionsXmlFilePath, updatedPermissionsXmlString, 'utf-8');
 
+}
+
+function processAllVariables(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissionOperation) {
+    Object.entries(groupPermissions).forEach(p => {
+        p.groupVariables.forEach( v => {
+            if (!p.wasSet && !permissions[v].wasSet) {
+                processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissionOperation == READ ? permissions[v].readPermission : permissions[v].writePermission)
+            }
+        })
+    })  
+}
+
+function processPermission(manifestXmlDoc, permissionsXmlDoc, arrayElement, permissionOperation) {
+    addEntryToManifest(manifestXmlDoc, permissionOperation)
+    addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permissionOperation)
 }
 
 function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser) {

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1123,10 +1123,9 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser) {
 
     const disableBackgroundJobs = configParser.getPlatformPreference('DisableBackgroundJobs', 'android');
-
-    console.log('disableBackgroundJobs: ' + disableBackgroundJobs);
-
-    if (disableBackgroundJobs == "false" || disableBackgroundJobs == "") {
+    
+    // we want to include the permissions by default
+    if (disableBackgroundJobs == false || disableBackgroundJobs == "") {
 
         const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
         const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { ConfigParser } = require('cordova-common');
 const et = require('elementtree');
 const { DOMParser, XMLSerializer } = require('xmldom');
+const { captureRejectionSymbol } = require('events');
 
 module.exports = async function (context) {
     const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
@@ -19,11 +20,92 @@ module.exports = async function (context) {
 
 function addPermissionsToManifest(configParser, projectRoot) {
 
+    // Permission groups
+    const fitnessPermissionsRead = [
+        { name: 'android.permission.health.READ_STEPS' },
+        { name: 'android.permission.health.READ_TOTAL_CALORIES_BURNED' },
+        { name: 'android.permission.health.READ_SPEED' },
+        { name: 'android.permission.health.READ_DISTANCE' }
+    ];
+
+    const fitnessPermissionsWrite = [
+        { name: 'android.permission.health.WRITE_STEPS' },
+        { name: 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED' },
+        { name: 'android.permission.health.WRITE_SPEED' },
+        { name: 'android.permission.health.WRITE_DISTANCE' }
+    ];
+
+    const healthPermissionsRead = [
+        { name: 'android.permission.health.READ_HEART_RATE' },
+        { name: 'android.permission.health.READ_SLEEP' },
+        { name: 'android.permission.health.READ_BLOOD_PRESSURE' },
+        { name: 'android.permission.health.READ_BLOOD_GLUCOSE' }
+    ];
+
+    const healthPermissionsWrite = [
+        { name: 'android.permission.health.WRITE_HEART_RATE' },
+        { name: 'android.permission.health.WRITE_SLEEP' },
+        { name: 'android.permission.health.WRITE_BLOOD_PRESSURE' },
+        { name: 'android.permission.health.WRITE_BLOOD_GLUCOSE' }
+    ];
+
+    const profilePermissionsRead = [
+        { name: 'android.permission.health.READ_WEIGHT' },
+        { name: 'android.permission.health.READ_HEIGHT' },
+        { name: 'android.permission.health.READ_BODY_FAT' },
+        { name: 'android.permission.health.READ_BASAL_METABOLIC_RATE' }
+    ];
+
+    const profilePermissionsWrite = [
+        { name: 'android.permission.health.WRITE_WEIGHT' },
+        { name: 'android.permission.health.WRITE_HEIGHT' },
+        { name: 'android.permission.health.WRITE_BODY_FAT' },
+        { name: 'android.permission.health.WRITE_BASAL_METABOLIC_RATE' }
+    ];
+
     //get all the preferences from config.xml, for every Health Connect permission
     const allVariables = configParser.getPlatformPreference('AllVariables', 'android');
     const fitnessVariables = configParser.getPlatformPreference('FitnessVariables', 'android');
     const healthVariables = configParser.getPlatformPreference('HealthVariables', 'android');
     const profileVariables = configParser.getPlatformPreference('ProfileVariables', 'android');
+
+    // individual variables
+    const heartRate = configParser.getPlatformPreference('HeartRate', 'android');
+    const steps = configParser.getPlatformPreference('Steps', 'android');
+    const weight = configParser.getPlatformPreference('Weight', 'android');
+    const height = configParser.getPlatformPreference('Height', 'android');
+    const calories = configParser.getPlatformPreference('CaloriesBurned', 'android');
+    const sleep = configParser.getPlatformPreference('Sleep', 'android');
+    const bloodPressure = configParser.getPlatformPreference('BloodPressure', 'android');
+    const bloodGlucose = configParser.getPlatformPreference('BloodGlucose', 'android');
+    const bodyFat = configParser.getPlatformPreference('BodyFatPercentage', 'android');
+    const bmr = configParser.getPlatformPreference('BasalMetabolicRate', 'android');
+    const speed = configParser.getPlatformPreference('WalkingSpeed', 'android');
+    const distance = configParser.getPlatformPreference('Distance', 'android');
+
+    // we'll use these to know if we should set individual permissions or not
+    // e.g. when checking HeartRate, if all healthVariables were already set, we don't need to add it again
+    var fitnessSet = false
+    var healthSet = false
+    var profileSet = false
+
+    // we'll use these to know if we should write group permissions or not
+    var heartRateSet = false
+    var stepsSet = false
+    var weightSet = false
+    var heightSet = false
+    var caloriesSet = false
+    var sleepSet = false
+    var bloodPressureSet = false
+    var bloodGlucoseSet = false
+    var bodyFatSet = false
+    var bmrSet = false
+    var speedSet = false
+    var distanceSet = false
+
+
+
+    // Android >= 14 dependencies, which should be included directly in the AndroidManifest.xml file
 
     console.log('About to read the AndroidManifest.xml file');
 
@@ -39,9 +121,818 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
     console.log('About to append permission');
 
+    /*
     const newPermission = manifestXmlDoc.createElement('uses-permission');
     newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
     manifestXmlDoc.documentElement.appendChild(newPermission);
+    */
+
+    // heartRate
+    if (heartRate == "ReadWrite" || heartRate == "Read") {
+        heartRateSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (heartRate == "ReadWrite" || heartRate == "Write") {
+        heartRateSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // steps
+    if (steps == "ReadWrite" || steps == "Read") {
+        stepsSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (steps == "ReadWrite" || steps == "Write") {
+        stepsSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // weight
+    if (weight == "ReadWrite" || weight == "Read") {
+        weightSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (steps == "ReadWrite" || steps == "Write") {
+        stepsSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // height
+    if (height == "ReadWrite" || height == "Read") {
+        heightSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (height == "ReadWrite" || height == "Write") {
+        heightSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // calories
+    if (calories == "ReadWrite" || calories == "Read") {
+        caloriesSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (calories == "ReadWrite" || calories == "Write") {
+        caloriesSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // sleep
+    if (sleep == "ReadWrite" || sleep == "Read") {
+        sleepSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (sleep == "ReadWrite" || sleep == "Write") {
+        sleepSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // blood pressure
+    if (bloodPressure == "ReadWrite" || bloodPressure == "Read") {
+        bloodPressureSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (bloodPressure == "ReadWrite" || bloodPressure == "Write") {
+        bloodPressureSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // blood glucose
+    if (bloodGlucose == "ReadWrite" || bloodGlucose == "Read") {
+        bloodGlucoseSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (bloodGlucose == "ReadWrite" || bloodGlucose == "Write") {
+        bloodGlucoseSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // body fat
+    if (bodyFat == "ReadWrite" || bodyFat == "Read") {
+        bodyFatSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (bodyFat == "ReadWrite" || bodyFat == "Write") {
+        bodyFatSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // bmr
+    if (bmr == "ReadWrite" || bmr == "Read") {
+        bmrSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (bmr == "ReadWrite" || bmr == "Write") {
+        bmr = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // speed
+    if (speed == "ReadWrite" || speed == "Read") {
+        speedSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (speed == "ReadWrite" || speed == "Write") {
+        speedSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // distance
+    if (distance == "ReadWrite" || distance == "Read") {
+        distanceSet = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    if (distance == "ReadWrite" || distance == "Write") {
+        distance = true
+
+        const newPermission = manifestXmlDoc.createElement('uses-permission');
+        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
+        manifestXmlDoc.documentElement.appendChild(newPermission);
+    }
+
+    // process fitness variables
+    if (fitnessVariables == "ReadWrite" || fitnessVariables == "Read") {
+
+        
+
+        if (!stepsSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!caloriesSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+    if (allVariables == "ReadWrite") {
+        // in this case, we don't look for any other preferences
+        // add all the read and write permissions for all the variables we have
+        
+        fitnessPermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+        
+        fitnessPermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        healthPermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+        
+        healthPermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        profilePermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+        
+        profilePermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+    } else if (allVariables == "Read") {
+
+        // in this case, we don't look for any other preferences
+        // add all the read permissions for all the variables we have
+
+        fitnessPermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        healthPermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        profilePermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+    } else if (allVariables == "Write") {
+        // in this case, we don't look for any other preferences
+        // add all the write permissions for all the variables we have
+
+        fitnessPermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        healthPermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        profilePermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+    } else if (fitnessVariables === undefined && healthVariables === undefined && profileVariables === undefined
+        && heartRate === undefined && steps === undefined && weight === undefined && height === undefined
+        && calories === undefined && sleep === undefined && bloodPressure === undefined && bloodGlucose === undefined
+        && bodyFat === undefined && bmr === undefined && speed == undefined && distance == undefined) {
+        // no other permission preferences are defined, so we want to add all permissions by default
+        fitnessPermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+        
+        fitnessPermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        healthPermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+        
+        healthPermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+
+        profilePermissionsRead.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+        
+        profilePermissionsWrite.forEach(permission => {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', permission.name);
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        });
+    } else {
+
+        //check fitness variables
+        if (fitnessVariables == "ReadWrite") {
+
+            fitnessRead = true
+            fitnessWrite = true
+            
+            fitnessPermissionsRead.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+            
+            fitnessPermissionsWrite.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+
+        } else if (fitnessVariables == "Read") {
+            
+            fitnessRead= true
+
+            fitnessPermissionsRead.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+
+        } else if (fitnessVariables == "Write") {
+
+            fitnessWrite = true
+
+            fitnessPermissionsWrite.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+        }
+
+        //check health variables
+        if (healthVariables == "ReadWrite") {
+
+            healthRead = true
+            healthWrite = true
+            
+            healthPermissionsRead.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+            
+            healthPermissionsWrite.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+
+        } else if (healthVariables == "Read") {
+
+            healthRead = true
+
+            healthPermissionsRead.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+
+        } else if (healthVariables == "Write") {
+
+            healthWrite = true
+
+            healthPermissionsWrite.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+        }
+
+        //check profile variables
+        if (profileVariables == "ReadWrite") {
+
+            profileRead = true
+            profileWrite = true
+            
+            profilePermissionsRead.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+            
+            profilePermissionsWrite.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+
+        } else if (profileVariables == "Read") {
+
+            profileRead = true
+
+            profilePermissionsRead.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+
+        } else if (profileVariables == "Write") {
+
+            profileWrite = true
+
+            profilePermissionsWrite.forEach(permission => {
+                const newPermission = manifestXmlDoc.createElement('uses-permission');
+                newPermission.setAttribute('android:name', permission.name);
+                manifestXmlDoc.documentElement.appendChild(newPermission);
+            });
+        }
+
+        //check all individual variables
+        if (heartRate == "ReadWrite") {
+
+            if (healthRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (healthWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);
+            }
+            
+
+        } else if (heartRate == "Read" && healthRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);
+
+        } else if (heartRate == "Write" && healthWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);
+
+        }
+
+        if (steps == "ReadWrite") {
+
+            if (fitnessRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (fitnessWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);
+            }
+
+        } else if (steps == "Read" && fitnessRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);
+
+        } else if (steps == "Write" && fitnessWrite == false) {
+            
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);
+
+        }
+
+        if (weight == "ReadWrite") {
+
+            if (profileRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (profileWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);
+            }
+
+        } else if (weight == "Read" && profileRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);
+
+        } else if (weight == "Write" && profileWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);
+            
+        }
+
+        if (height == "ReadWrite") {
+
+            if (profileRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (profileWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);
+            }
+
+        } else if (height == "Read" && profileRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);
+
+        } else if (height == "Write" && profileWrite == false) {
+            
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);
+
+        }
+
+        if (calories == "ReadWrite") {
+
+            if (fitnessRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (fitnessWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);    
+            }
+        
+        } else if (calories == "Read" && fitnessRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);            
+
+        } else if (calories == "Write" && fitnessWrite == false) {
+            
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);
+
+        }
+
+        if (sleep == "ReadWrite") {
+
+            if (healthRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (healthWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);    
+            }
+
+        } else if (sleep == "Read" && healthRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (sleep == "Write" && healthWrite == false) {
+            
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+
+        }
+
+        if (bloodPressure == "ReadWrite") {
+
+            if (healthRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (healthWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);    
+            }
+
+        } else if (bloodPressure == "Read" && healthRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (bloodPressure == "Write" && healthWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+            
+        }
+
+        if (bloodGlucose == "ReadWrite") {
+
+            if (healthRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (healthWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);      
+            }
+
+        } else if (bloodGlucose == "Read" && healthRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (bloodGlucose == "Write" && healthWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+            
+        }
+
+        if (bodyFat == "ReadWrite") {
+
+            if (profileRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (profileWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);
+            }
+
+        } else if (bodyFat == "Read" && profileRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (bodyFat == "Write" && profileWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+            
+        }
+
+        if (bmr == "ReadWrite") {
+
+            if (profileRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (profileWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);  
+            }
+
+        } else if (bmr == "Read" && profileRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (bmr == "Write" && profileWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+            
+        }
+
+        if (speed == "ReadWrite") {
+
+            if (fitnessRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (fitnessWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);      
+            }
+
+        } else if (speed == "Read" && fitnessRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (speed == "Write" && fitnessWrite == false) {
+            
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+
+        }
+
+        if (distance == "ReadWrite") {
+
+            if (fitnessRead == false) {
+                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
+                manifestXmlDoc.documentElement.appendChild(newReadPermission);
+            }
+
+            if (fitnessWrite == false) {
+                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
+                manifestXmlDoc.documentElement.appendChild(newWritePermission);         
+            }
+
+        } else if (distance == "Read" && fitnessRead == false) {
+
+            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
+            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
+            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
+
+        } else if (distance == "Write" && fitnessWrite == false) {
+
+            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
+            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
+            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
+            
+        }
+        
+    }
 
     console.log('About to serialize');
 
@@ -53,37 +944,8 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
     // Write the updated XML string back to the same file
     fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');
-
-    /*
-
-    if (allVariables == "true") {
-        // in this case, we don't look for any other preferences
-        // add all the permissions for all the variables we have
-        
-    } else if (fitnessVariables == "true") {
-        // add all permissions for fitness variables
-
-    } else if (healthVariables == "true") {
-        // add all permissions for health variables
-
-    } else if (profileVariables == "true") {
-        // add all permissions for profile variables
-
-    } else {
-        // look for every variable individually and add the permission for it if its value is true
-
-    }
-
-    */
-
-    // for every permission that is present in the config.xml file, we add it to the AndroidManifest.xml file
-
-    // finally, we save the file by doing the following
     
-    /*
-    let resultXmlStrings = etreeStrings.write();
-    fs.writeFileSync(stringsPath, resultXmlStrings);
-    */
+    
 
 
 }

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -128,6 +128,7 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         heartRateSet = true
 
         // Android >= 14
+        /*
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
         manifestXmlDoc.documentElement.appendChild(newPermission);
@@ -137,6 +138,9 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
         newItem.appendChild(textNode);
         arrayElement.appendChild(newItem);
+        */
+
+        addEntryToManifestAndPermissionsXml('android.permission.health.READ_HEART_RATE');
     }
 
     if (heartRate == "ReadWrite" || heartRate == "Write") {
@@ -1121,6 +1125,22 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
     // Write the updated XML string back to the same file
     fs.writeFileSync(permissionsXmlFilePath, updatedPermissionsXmlString, 'utf-8');
 
+}
+
+function addEntryToManifestAndPermissionsXml(permission) {
+
+    console.log("entered addEntryToManifestAndPermissionsXml");
+
+    // Android >= 14
+    const newPermission = manifestXmlDoc.createElement('uses-permission');
+    newPermission.setAttribute('android:name', permission);
+    manifestXmlDoc.documentElement.appendChild(newPermission);
+
+    // Android <= 13
+    const newItem = permissionsXmlDoc.createElement('item');
+    const textNode = permissionsXmlDoc.createTextNode(permission);
+    newItem.appendChild(textNode);
+    arrayElement.appendChild(newItem);
 }
 
 function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser) {

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1176,13 +1176,17 @@ function copyNotificationContent(configParser, projectRoot, parser) {
 
     console.log('strings.xml: ' + stringsXmlString);
 
+    stringsXmlDoc.getElementsByTagName
+
     const titleElement = stringsXmlDoc.getElementById('background_notification_title');
+    console.log('titleElement: ' + titleElement);
     if (titleElement) {
         console.log('Setting Title');
         titleElement.textContent = notificationTitle;
     }
 
     const descriptionElement = stringsXmlDoc.getElementById('background_notification_description');
+    console.log('descriptionElement: ' + descriptionElement);
     if (descriptionElement) {
         console.log('Setting Description');
         descriptionElement.textContent = notificationDescription;

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1140,7 +1140,7 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
     }
 
     // we want to include the permissions by default
-    if (disableBackgroundJobs === false || disableBackgroundJobs == "") {
+    if (disableBackgroundJobs !== "true") {
 
         const manifestFilePath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
         const manifestXmlString = fs.readFileSync(manifestFilePath, 'utf-8');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -126,331 +126,157 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
     // heartRate
     if (heartRate == "ReadWrite" || heartRate == "Read") {
         heartRateSet = true
-
-        // Android >= 14
-        /*
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        // Android <= 13
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
-        */
-
-        addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE');
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEART_RATE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE')
     }
 
     if (heartRate == "ReadWrite" || heartRate == "Write") {
         heartRateSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEART_RATE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEART_RATE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEART_RATE')
     }
 
     // steps
     if (steps == "ReadWrite" || steps == "Read") {
         stepsSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_STEPS');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_STEPS')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_STEPS')
     }
 
     if (steps == "ReadWrite" || steps == "Write") {
         stepsSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_STEPS');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_STEPS')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_STEPS')
     }
 
     // weight
     if (weight == "ReadWrite" || weight == "Read") {
         weightSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_WEIGHT');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_WEIGHT')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_WEIGHT')
     }
 
     if (weight == "ReadWrite" || weight == "Write") {
         weightSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_WEIGHT');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_WEIGHT')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_WEIGHT')
     }
 
     // height
     if (height == "ReadWrite" || height == "Read") {
         heightSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEIGHT');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEIGHT')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEIGHT')
     }
 
     if (height == "ReadWrite" || height == "Write") {
         heightSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEIGHT');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEIGHT')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEIGHT')
     }
 
     // calories
     if (calories == "ReadWrite" || calories == "Read") {
         caloriesSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_TOTAL_CALORIES_BURNED');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
     }
 
     if (calories == "ReadWrite" || calories == "Write") {
         caloriesSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
     }
 
     // sleep
     if (sleep == "ReadWrite" || sleep == "Read") {
         sleepSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SLEEP');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SLEEP')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SLEEP')
     }
 
     if (sleep == "ReadWrite" || sleep == "Write") {
         sleepSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SLEEP');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SLEEP')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SLEEP')
     }
 
     // blood pressure
     if (bloodPressure == "ReadWrite" || bloodPressure == "Read") {
         bloodPressureSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_PRESSURE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_PRESSURE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_PRESSURE')
     }
 
     if (bloodPressure == "ReadWrite" || bloodPressure == "Write") {
         bloodPressureSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_PRESSURE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_PRESSURE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_PRESSURE')
     }
 
     // blood glucose
     if (bloodGlucose == "ReadWrite" || bloodGlucose == "Read") {
         bloodGlucoseSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_GLUCOSE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_GLUCOSE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_GLUCOSE')
     }
 
     if (bloodGlucose == "ReadWrite" || bloodGlucose == "Write") {
         bloodGlucoseSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_GLUCOSE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
     }
 
     // body fat
     if (bodyFat == "ReadWrite" || bodyFat == "Read") {
         bodyFatSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BODY_FAT');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BODY_FAT')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BODY_FAT')
     }
 
     if (bodyFat == "ReadWrite" || bodyFat == "Write") {
         bodyFatSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BODY_FAT');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BODY_FAT')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BODY_FAT')
     }
 
     // bmr
     if (bmr == "ReadWrite" || bmr == "Read") {
         bmrSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BASAL_METABOLIC_RATE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
     }
 
     if (bmr == "ReadWrite" || bmr == "Write") {
         bmrSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
     }
 
     // speed
     if (speed == "ReadWrite" || speed == "Read") {
         speedSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SPEED');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SPEED')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SPEED')
     }
 
     if (speed == "ReadWrite" || speed == "Write") {
         speedSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SPEED');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SPEED')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SPEED')
     }
 
     // distance
     if (distance == "ReadWrite" || distance == "Read") {
         distanceSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_DISTANCE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_DISTANCE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_DISTANCE')
     }
 
     if (distance == "ReadWrite" || distance == "Write") {
         distanceSet = true
-
-        const newPermission = manifestXmlDoc.createElement('uses-permission');
-        newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
-        manifestXmlDoc.documentElement.appendChild(newPermission);
-
-        const newItem = permissionsXmlDoc.createElement('item');
-        const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_DISTANCE');
-        newItem.appendChild(textNode);
-        arrayElement.appendChild(newItem);
+        addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_DISTANCE')
+        addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_DISTANCE')
     }
 
     // process fitness variables
@@ -459,47 +285,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         fitnessSet = true
 
         if (!stepsSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_STEPS');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_STEPS')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_STEPS')
         }
 
         if (!caloriesSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_TOTAL_CALORIES_BURNED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
         }
 
         if (!speedSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SPEED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SPEED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SPEED')
         }
 
         if (!distanceSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_DISTANCE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_DISTANCE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_DISTANCE')
         }
 
     }
@@ -509,47 +311,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         fitnessSet = true
 
         if (!stepsSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_STEPS');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_STEPS')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_STEPS')
         }
 
         if (!caloriesSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
         }
 
         if (!speedSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SPEED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SPEED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SPEED')
         }
 
         if (!distanceSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_DISTANCE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_DISTANCE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_DISTANCE')
         }
 
     }
@@ -560,47 +338,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         healthSet = true
 
         if (!heartRateSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEART_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE')
         }
 
         if (!sleepSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SLEEP');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SLEEP')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SLEEP')
         }
 
         if (!bloodPressureSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_PRESSURE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_PRESSURE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_PRESSURE')
         }
 
         if (!bloodGlucoseSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_GLUCOSE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_GLUCOSE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_GLUCOSE')
         }
 
     }
@@ -610,47 +364,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         healthSet = true
 
         if (!heartRateSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEART_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEART_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEART_RATE')
         }
 
         if (!sleepSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SLEEP');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SLEEP')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SLEEP')
         }
 
         if (!bloodPressureSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_PRESSURE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_PRESSURE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_PRESSURE')
         }
 
         if (!bloodGlucoseSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_GLUCOSE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
         }
 
     }
@@ -661,47 +391,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         profileSet = true
 
         if (!weightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_WEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_WEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_WEIGHT')
         }
 
         if (!heightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEIGHT')
         }
 
         if (!bodyFatSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BODY_FAT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BODY_FAT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BODY_FAT')
         }
 
         if (!bmrSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BASAL_METABOLIC_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
         }
 
     }
@@ -711,47 +417,23 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         profileSet = true
 
         if (!weightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_WEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_WEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_WEIGHT')
         }
 
         if (!heightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEIGHT')
         }
 
         if (!bodyFatSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BODY_FAT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BODY_FAT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BODY_FAT')
         }
 
         if (!bmrSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
         }
 
     }
@@ -763,137 +445,65 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 
         // fitness
         if (!fitnessSet && !stepsSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_STEPS');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_STEPS')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_STEPS')
         }
 
         if (!fitnessSet && !caloriesSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_TOTAL_CALORIES_BURNED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_TOTAL_CALORIES_BURNED')
         }
 
         if (!fitnessSet && !speedSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SPEED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SPEED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SPEED')
         }
 
         if (!fitnessSet && !distanceSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_DISTANCE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_DISTANCE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_DISTANCE')
         }
 
         // health
         if (!healthSet && !heartRateSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEART_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEART_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEART_RATE')
         }
 
         if (!healthSet && !sleepSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_SLEEP');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_SLEEP')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_SLEEP')
         }
 
         if (!healthSet && !bloodPressureSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_PRESSURE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_PRESSURE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_PRESSURE')
         }
 
         if (!healthSet && !bloodGlucoseSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BLOOD_GLUCOSE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BLOOD_GLUCOSE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BLOOD_GLUCOSE')
         }
 
         // profile
         if (!profileSet && !weightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_WEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_WEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_WEIGHT')
         }
 
         if (!profileSet && !heightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_HEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_HEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_HEIGHT')
         }
 
         if (!profileSet && !bodyFatSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BODY_FAT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BODY_FAT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BODY_FAT')
         }
 
         if (!profileSet && !bmrSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.READ_BASAL_METABOLIC_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.READ_BASAL_METABOLIC_RATE')
         }
         
     }
@@ -902,137 +512,65 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 
         // fitness
         if (!fitnessSet && !stepsSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_STEPS');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_STEPS')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_STEPS')
         }
 
         if (!fitnessSet && !caloriesSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED')
         }
 
         if (!fitnessSet && !speedSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SPEED');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SPEED')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SPEED')
         }
 
         if (!fitnessSet && !distanceSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_DISTANCE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_DISTANCE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_DISTANCE')
         }
 
         // health
         if (!healthSet && !heartRateSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEART_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEART_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEART_RATE')
         }
 
         if (!healthSet && !sleepSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_SLEEP');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_SLEEP')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_SLEEP')
         }
 
         if (!healthSet && !bloodPressureSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_PRESSURE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_PRESSURE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_PRESSURE')
         }
 
         if (!healthSet && !bloodGlucoseSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BLOOD_GLUCOSE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BLOOD_GLUCOSE')
         }
 
         // profile
         if (!profileSet && !weightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_WEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_WEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_WEIGHT')
         }
 
         if (!profileSet && !heightSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_HEIGHT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_HEIGHT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_HEIGHT')
         }
 
         if (!profileSet && !bodyFatSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BODY_FAT');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BODY_FAT')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BODY_FAT')
         }
 
         if (!profileSet && !bmrSet) {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-
-            const newItem = permissionsXmlDoc.createElement('item');
-            const textNode = permissionsXmlDoc.createTextNode('android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-            newItem.appendChild(textNode);
-            arrayElement.appendChild(newItem);
+            addEntryToManifest(manifestXmlDoc, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
+            addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, 'android.permission.health.WRITE_BASAL_METABOLIC_RATE')
         }
         
     }
@@ -1044,69 +582,33 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
         && bodyFat == "" && bmr == "" && speed == "" && distance == "") {
 
             fitnessPermissionsRead.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-
-                const newItem = permissionsXmlDoc.createElement('item');
-                const textNode = permissionsXmlDoc.createTextNode(permission.name);
-                newItem.appendChild(textNode);
-                arrayElement.appendChild(newItem);
+                addEntryToManifest(manifestXmlDoc, permission.name)
+                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
             });
             
             fitnessPermissionsWrite.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-
-                const newItem = permissionsXmlDoc.createElement('item');
-                const textNode = permissionsXmlDoc.createTextNode(permission.name);
-                newItem.appendChild(textNode);
-                arrayElement.appendChild(newItem);
+                addEntryToManifest(manifestXmlDoc, permission.name)
+                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
             });
     
             healthPermissionsRead.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-
-                const newItem = permissionsXmlDoc.createElement('item');
-                const textNode = permissionsXmlDoc.createTextNode(permission.name);
-                newItem.appendChild(textNode);
-                arrayElement.appendChild(newItem);
+                addEntryToManifest(manifestXmlDoc, permission.name)
+                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
             });
             
             healthPermissionsWrite.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-
-                const newItem = permissionsXmlDoc.createElement('item');
-                const textNode = permissionsXmlDoc.createTextNode(permission.name);
-                newItem.appendChild(textNode);
-                arrayElement.appendChild(newItem);
+                addEntryToManifest(manifestXmlDoc, permission.name)
+                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
             });
     
             profilePermissionsRead.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-
-                const newItem = permissionsXmlDoc.createElement('item');
-                const textNode = permissionsXmlDoc.createTextNode(permission.name);
-                newItem.appendChild(textNode);
-                arrayElement.appendChild(newItem);
+                addEntryToManifest(manifestXmlDoc, permission.name)
+                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
             });
             
             profilePermissionsWrite.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-
-                const newItem = permissionsXmlDoc.createElement('item');
-                const textNode = permissionsXmlDoc.createTextNode(permission.name);
-                newItem.appendChild(textNode);
-                arrayElement.appendChild(newItem);
+                addEntryToManifest(manifestXmlDoc, permission.name)
+                addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission.name)
             });
 
         }
@@ -1127,22 +629,6 @@ function addHealthConnectPermissionsToXmlFiles(configParser, projectRoot, parser
 
 }
 
-function addEntryToManifestAndPermissionsXml(manifestXmlDoc, permissionsXmlDoc, arrayElement, permission) {
-
-    console.log("entered addEntryToManifestAndPermissionsXml");
-
-    // Android >= 14
-    const newPermission = manifestXmlDoc.createElement('uses-permission');
-    newPermission.setAttribute('android:name', permission);
-    manifestXmlDoc.documentElement.appendChild(newPermission);
-
-    // Android <= 13
-    const newItem = permissionsXmlDoc.createElement('item');
-    const textNode = permissionsXmlDoc.createTextNode(permission);
-    newItem.appendChild(textNode);
-    arrayElement.appendChild(newItem);
-}
-
 function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser) {
 
     const disableBackgroundJobs = configParser.getPlatformPreference('DisableBackgroundJobs', 'android');
@@ -1157,25 +643,12 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
         // Parse the XML string
         const manifestXmlDoc = parser.parseFromString(manifestXmlString, 'text/xml');
 
-        const notificationsPermission = manifestXmlDoc.createElement('uses-permission');
-        notificationsPermission.setAttribute('android:name', 'android.permission.POST_NOTIFICATIONS');
-        manifestXmlDoc.documentElement.appendChild(notificationsPermission);
-
-        const activityPermission = manifestXmlDoc.createElement('uses-permission');
-        activityPermission.setAttribute('android:name', 'android.permission.ACTIVITY_RECOGNITION');
-        manifestXmlDoc.documentElement.appendChild(activityPermission);
-
-        const foregroundServicePermission = manifestXmlDoc.createElement('uses-permission');
-        foregroundServicePermission.setAttribute('android:name', 'android.permission.FOREGROUND_SERVICE');
-        manifestXmlDoc.documentElement.appendChild(foregroundServicePermission);
-
-        const foregroundServiceHealthPermission = manifestXmlDoc.createElement('uses-permission');
-        foregroundServiceHealthPermission.setAttribute('android:name', 'android.permission.FOREGROUND_SERVICE_HEALTH');
-        manifestXmlDoc.documentElement.appendChild(foregroundServiceHealthPermission);
-
-        const highSamplingPermission = manifestXmlDoc.createElement('uses-permission');
-        highSamplingPermission.setAttribute('android:name', 'android.permission.HIGH_SAMPLING_RATE_SENSORS');
-        manifestXmlDoc.documentElement.appendChild(highSamplingPermission);
+        // add permissions to XML document
+        addEntryToManifest(manifestXmlDoc, 'android.permission.POST_NOTIFICATIONS')
+        addEntryToManifest(manifestXmlDoc, 'android.permission.ACTIVITY_RECOGNITION')
+        addEntryToManifest(manifestXmlDoc, 'android.permission.FOREGROUND_SERVICE')
+        addEntryToManifest(manifestXmlDoc, 'android.permission.FOREGROUND_SERVICE_HEALTH')
+        addEntryToManifest(manifestXmlDoc, 'android.permission.HIGH_SAMPLING_RATE_SENSORS')
 
         // serialize the updated XML document back to string
         const serializer = new XMLSerializer();
@@ -1185,6 +658,19 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
         fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');
     }
 
+}
+
+function addEntryToManifest(manifestXmlDoc, permission) {
+    const newPermission = manifestXmlDoc.createElement('uses-permission');
+    newPermission.setAttribute('android:name', permission);
+    manifestXmlDoc.documentElement.appendChild(newPermission);
+}
+
+function addEntryToPermissionsXML(permissionsXmlDoc, arrayElement, permission) {
+    const newItem = permissionsXmlDoc.createElement('item');
+    const textNode = permissionsXmlDoc.createTextNode(permission);
+    newItem.appendChild(textNode);
+    arrayElement.appendChild(newItem);
 }
 
 function copyNotificationContent(configParser, projectRoot, parser) {

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -675,18 +675,11 @@ function addPermissionsToManifest(configParser, projectRoot) {
         
     }
 
-    console.log('allVariables: ' + allVariables);
-
-    if (allVariables == "") {
-        console.log('allVariables is undefined');
-    }
-
-
     // if there is no AllVariables nor anything else, then by default we add all the permissions
-    if (allVariables == null && fitnessVariables == null && healthVariables == null && profileVariables == null
-        && heartRate == null && steps == null && weight == null && height == null
-        && calories == null && sleep == null && bloodPressure == null && bloodGlucose == null
-        && bodyFat == null && bmr == null && speed == null && distance == null) {
+    if (allVariables == "" && fitnessVariables == "" && healthVariables == "" && profileVariables == ""
+        && heartRate == "" && steps == "" && weight == "" && height == ""
+        && calories == "" && sleep == "" && bloodPressure == "" && bloodGlucose == ""
+        && bodyFat == "" && bmr == "" && speed == "" && distance == "") {
 
             fitnessPermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -675,6 +675,8 @@ function addPermissionsToManifest(configParser, projectRoot) {
         
     }
 
+    console.log('allVariables: ' + allVariables);
+
 
     // if there is no AllVariables nor anything else, then by default we add all the permissions
     if (allVariables == null && fitnessVariables == null && healthVariables == null && profileVariables == null

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1159,11 +1159,14 @@ function copyNotificationContent(configParser, projectRoot, parser) {
 
     // get values from config.xml
     var notificationTitle = configParser.getPlatformPreference('BackgroundNotificationTitle', 'android');
-    const notificationDescription = configParser.getPlatformPreference('BackgroundNotificationDescription', 'android');
+    var notificationDescription = configParser.getPlatformPreference('BackgroundNotificationDescription', 'android');
 
-    // we only want a default value for the title
     if (notificationTitle == "") {
         notificationTitle = "Measuring your health and fitness data."
+    }
+
+    if (notificationDescription == "") {
+        notificationDescription = "The app is running on the background."
     }
 
     // insert values in strings.xml

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -170,8 +170,8 @@ function addPermissionsToManifest(configParser, projectRoot) {
         manifestXmlDoc.documentElement.appendChild(newPermission);
     }
 
-    if (steps == "ReadWrite" || steps == "Write") {
-        stepsSet = true
+    if (weight == "ReadWrite" || weight == "Write") {
+        weightSet = true
 
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
@@ -290,7 +290,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
     }
 
     if (bmr == "ReadWrite" || bmr == "Write") {
-        bmr = true
+        bmrSet = true
 
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
@@ -324,7 +324,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
     }
 
     if (distance == "ReadWrite" || distance == "Write") {
-        distance = true
+        distanceSet = true
 
         const newPermission = manifestXmlDoc.createElement('uses-permission');
         newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
@@ -334,7 +334,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
     // process fitness variables
     if (fitnessVariables == "ReadWrite" || fitnessVariables == "Read") {
 
-        
+        fitnessSet = true
 
         if (!stepsSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
@@ -344,145 +344,344 @@ function addPermissionsToManifest(configParser, projectRoot) {
 
         if (!caloriesSet) {
             const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!speedSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!distanceSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+    if (fitnessVariables == "ReadWrite" || fitnessVariables == "Write") {
+
+        fitnessSet = true
+
+        if (!stepsSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!caloriesSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!speedSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!distanceSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+    // process health variables
+    if (healthVariables == "ReadWrite" || healthVariables == "Read") {
+
+        healthSet = true
+
+        if (!heartRateSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!sleepSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bloodPressureSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bloodGlucoseSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+    if (healthVariables == "ReadWrite" || healthVariables == "Write") {
+
+        healthSet = true
+
+        if (!heartRateSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!sleepSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bloodPressureSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bloodGlucoseSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+    // process profile variables
+    if (profileVariables == "ReadWrite" || profileVariables == "Read") {
+
+        profileSet = true
+
+        if (!weightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!heightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bodyFatSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bmrSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+    if (profileVariables == "ReadWrite" || profileVariables == "Write") {
+
+        profileSet = true
+
+        if (!weightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!heightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bodyFatSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!bmrSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+    }
+
+
+    // process AllVariables
+
+    if (allVariables == "ReadWrite" || allVariables == "Read") {
+
+        // fitness
+        if (!fitnessSet && !stepsSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
             newPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
             manifestXmlDoc.documentElement.appendChild(newPermission);
         }
 
+        if (!fitnessSet && !caloriesSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!fitnessSet && !speedSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!fitnessSet && !distanceSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        // health
+        if (!healthSet && !heartRateSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!healthSet && !sleepSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!healthSet && !bloodPressureSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!healthSet && !bloodGlucoseSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        // profile
+        if (!profileSet && !weightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!profileSet && !heightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!profileSet && !bodyFatSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!profileSet && !bmrSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+        
     }
 
-    if (allVariables == "ReadWrite") {
-        // in this case, we don't look for any other preferences
-        // add all the read and write permissions for all the variables we have
+    if (allVariables == "ReadWrite" || allVariables == "Write") {
+
+        // fitness
+        if (!fitnessSet && !stepsSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!fitnessSet && !caloriesSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!fitnessSet && !speedSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!fitnessSet && !distanceSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        // health
+        if (!healthSet && !heartRateSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!healthSet && !sleepSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!healthSet && !bloodPressureSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!healthSet && !bloodGlucoseSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        // profile
+        if (!profileSet && !weightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!profileSet && !heightSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!profileSet && !bodyFatSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
+
+        if (!profileSet && !bmrSet) {
+            const newPermission = manifestXmlDoc.createElement('uses-permission');
+            newPermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
+            manifestXmlDoc.documentElement.appendChild(newPermission);
+        }
         
-        fitnessPermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-        
-        fitnessPermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
+    }
 
-        healthPermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-        
-        healthPermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
 
-        profilePermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-        
-        profilePermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
+    // if there is no AllVariables nor anything else, then by default we add all the permissions
+    if (allVariables == null && fitnessVariables == null && healthVariables === null && profileVariables === null
+        && heartRate === null && steps === null && weight === null && height === null
+        && calories === null && sleep === null && bloodPressure === null && bloodGlucose === null
+        && bodyFat === null && bmr === null && speed == null && distance == null) {
 
-    } else if (allVariables == "Read") {
-
-        // in this case, we don't look for any other preferences
-        // add all the read permissions for all the variables we have
-
-        fitnessPermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-        healthPermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-        profilePermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-    } else if (allVariables == "Write") {
-        // in this case, we don't look for any other preferences
-        // add all the write permissions for all the variables we have
-
-        fitnessPermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-        healthPermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-        profilePermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-    } else if (fitnessVariables === undefined && healthVariables === undefined && profileVariables === undefined
-        && heartRate === undefined && steps === undefined && weight === undefined && height === undefined
-        && calories === undefined && sleep === undefined && bloodPressure === undefined && bloodGlucose === undefined
-        && bodyFat === undefined && bmr === undefined && speed == undefined && distance == undefined) {
-        // no other permission preferences are defined, so we want to add all permissions by default
-        fitnessPermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-        
-        fitnessPermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-        healthPermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-        
-        healthPermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-
-        profilePermissionsRead.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-        
-        profilePermissionsWrite.forEach(permission => {
-            const newPermission = manifestXmlDoc.createElement('uses-permission');
-            newPermission.setAttribute('android:name', permission.name);
-            manifestXmlDoc.documentElement.appendChild(newPermission);
-        });
-    } else {
-
-        //check fitness variables
-        if (fitnessVariables == "ReadWrite") {
-
-            fitnessRead = true
-            fitnessWrite = true
-            
             fitnessPermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
@@ -494,34 +693,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
             });
-
-        } else if (fitnessVariables == "Read") {
-            
-            fitnessRead= true
-
-            fitnessPermissionsRead.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-            });
-
-        } else if (fitnessVariables == "Write") {
-
-            fitnessWrite = true
-
-            fitnessPermissionsWrite.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-            });
-        }
-
-        //check health variables
-        if (healthVariables == "ReadWrite") {
-
-            healthRead = true
-            healthWrite = true
-            
+    
             healthPermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
@@ -533,34 +705,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
                 newPermission.setAttribute('android:name', permission.name);
                 manifestXmlDoc.documentElement.appendChild(newPermission);
             });
-
-        } else if (healthVariables == "Read") {
-
-            healthRead = true
-
-            healthPermissionsRead.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-            });
-
-        } else if (healthVariables == "Write") {
-
-            healthWrite = true
-
-            healthPermissionsWrite.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-            });
-        }
-
-        //check profile variables
-        if (profileVariables == "ReadWrite") {
-
-            profileRead = true
-            profileWrite = true
-            
+    
             profilePermissionsRead.forEach(permission => {
                 const newPermission = manifestXmlDoc.createElement('uses-permission');
                 newPermission.setAttribute('android:name', permission.name);
@@ -573,366 +718,7 @@ function addPermissionsToManifest(configParser, projectRoot) {
                 manifestXmlDoc.documentElement.appendChild(newPermission);
             });
 
-        } else if (profileVariables == "Read") {
-
-            profileRead = true
-
-            profilePermissionsRead.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-            });
-
-        } else if (profileVariables == "Write") {
-
-            profileWrite = true
-
-            profilePermissionsWrite.forEach(permission => {
-                const newPermission = manifestXmlDoc.createElement('uses-permission');
-                newPermission.setAttribute('android:name', permission.name);
-                manifestXmlDoc.documentElement.appendChild(newPermission);
-            });
         }
-
-        //check all individual variables
-        if (heartRate == "ReadWrite") {
-
-            if (healthRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (healthWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);
-            }
-            
-
-        } else if (heartRate == "Read" && healthRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEART_RATE');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);
-
-        } else if (heartRate == "Write" && healthWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEART_RATE');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);
-
-        }
-
-        if (steps == "ReadWrite") {
-
-            if (fitnessRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (fitnessWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);
-            }
-
-        } else if (steps == "Read" && fitnessRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_STEPS');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);
-
-        } else if (steps == "Write" && fitnessWrite == false) {
-            
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_STEPS');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);
-
-        }
-
-        if (weight == "ReadWrite") {
-
-            if (profileRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (profileWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);
-            }
-
-        } else if (weight == "Read" && profileRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_WEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);
-
-        } else if (weight == "Write" && profileWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_WEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);
-            
-        }
-
-        if (height == "ReadWrite") {
-
-            if (profileRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (profileWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);
-            }
-
-        } else if (height == "Read" && profileRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_HEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);
-
-        } else if (height == "Write" && profileWrite == false) {
-            
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_HEIGHT');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);
-
-        }
-
-        if (calories == "ReadWrite") {
-
-            if (fitnessRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (fitnessWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);    
-            }
-        
-        } else if (calories == "Read" && fitnessRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_TOTAL_CALORIES_BURNED');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);            
-
-        } else if (calories == "Write" && fitnessWrite == false) {
-            
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_TOTAL_CALORIES_BURNED');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);
-
-        }
-
-        if (sleep == "ReadWrite") {
-
-            if (healthRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (healthWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);    
-            }
-
-        } else if (sleep == "Read" && healthRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SLEEP');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (sleep == "Write" && healthWrite == false) {
-            
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SLEEP');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-
-        }
-
-        if (bloodPressure == "ReadWrite") {
-
-            if (healthRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (healthWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);    
-            }
-
-        } else if (bloodPressure == "Read" && healthRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_PRESSURE');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (bloodPressure == "Write" && healthWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_PRESSURE');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-            
-        }
-
-        if (bloodGlucose == "ReadWrite") {
-
-            if (healthRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (healthWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);      
-            }
-
-        } else if (bloodGlucose == "Read" && healthRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BLOOD_GLUCOSE');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (bloodGlucose == "Write" && healthWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BLOOD_GLUCOSE');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-            
-        }
-
-        if (bodyFat == "ReadWrite") {
-
-            if (profileRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (profileWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);
-            }
-
-        } else if (bodyFat == "Read" && profileRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BODY_FAT');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (bodyFat == "Write" && profileWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BODY_FAT');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-            
-        }
-
-        if (bmr == "ReadWrite") {
-
-            if (profileRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (profileWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);  
-            }
-
-        } else if (bmr == "Read" && profileRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_BASAL_METABOLIC_RATE');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (bmr == "Write" && profileWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_BASAL_METABOLIC_RATE');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-            
-        }
-
-        if (speed == "ReadWrite") {
-
-            if (fitnessRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (fitnessWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);      
-            }
-
-        } else if (speed == "Read" && fitnessRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_SPEED');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (speed == "Write" && fitnessWrite == false) {
-            
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_SPEED');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-
-        }
-
-        if (distance == "ReadWrite") {
-
-            if (fitnessRead == false) {
-                const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-                newReadPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
-                manifestXmlDoc.documentElement.appendChild(newReadPermission);
-            }
-
-            if (fitnessWrite == false) {
-                const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-                newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
-                manifestXmlDoc.documentElement.appendChild(newWritePermission);         
-            }
-
-        } else if (distance == "Read" && fitnessRead == false) {
-
-            const newReadPermission = manifestXmlDoc.createElement('uses-permission');
-            newReadPermission.setAttribute('android:name', 'android.permission.health.READ_DISTANCE');
-            manifestXmlDoc.documentElement.appendChild(newReadPermission);     
-
-        } else if (distance == "Write" && fitnessWrite == false) {
-
-            const newWritePermission = manifestXmlDoc.createElement('uses-permission');
-            newWritePermission.setAttribute('android:name', 'android.permission.health.WRITE_DISTANCE');
-            manifestXmlDoc.documentElement.appendChild(newWritePermission);     
-            
-        }
-        
-    }
 
     console.log('About to serialize');
 
@@ -945,7 +731,5 @@ function addPermissionsToManifest(configParser, projectRoot) {
     // Write the updated XML string back to the same file
     fs.writeFileSync(manifestFilePath, updatedManifestXmlString, 'utf-8');
     
-    
-
 
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
       "ios"
     ]
   },
-  "engines": []
+  "engines": [],
+  "dependencies": {
+    "xmldom": "^0.6.0"
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,11 @@
       <preference name="AndroidXEnabled" value="true"/>
     </config-file>
 
+    <config-file parent="/*" target="res/values/strings.xml">
+      <string name="background_notification_title"></string>
+      <string name="background_notification_description"></string>
+   </config-file>
+
     <!-- HealthFitness Plugin -->
     <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,13 +20,6 @@
       <preference name="AndroidXEnabled" value="true"/>
     </config-file>
 
-    <config-file parent="/*" target="AndroidManifest.xml">
-      <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-      <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
-      <uses-permission android:name="android.permission.BODY_SENSORS" />
-      <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND" />
-    </config-file>
-
     <!-- HealthFitness Plugin -->
     <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
   </js-module>
   <platform name="android">
 
-    <hook type="after_prepare" src="hooks/hooks/androidCopyPreferencesPermissions.js" />
+    <hook type="after_prepare" src="hooks/androidCopyPreferencesPermissions.js" />
 
     <config-file parent="/*" target="res/xml/config.xml">
       <feature name="OSHealthFitness">

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,6 +25,20 @@
       <string name="background_notification_description"></string>
    </config-file>
 
+   <config-file target="AndroidManifest.xml" parent="/manifest/application">
+      <activity
+        android:name=".PermissionsRationaleActivity"
+        android:theme="@style/Theme.AppCompat"
+        android:exported="true">
+        <intent-filter>
+          <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+        </intent-filter>
+        <meta-data
+          android:name="health_permissions"
+          android:resource="@array/health_permissions" />
+      </activity>
+    </config-file>
+
     <!-- HealthFitness Plugin -->
     <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,6 +8,8 @@
   </js-module>
   <platform name="android">
 
+    <hook type="after_prepare" src="hooks/hooks/androidCopyPreferencesPermissions.js" />
+
     <config-file parent="/*" target="res/xml/config.xml">
       <feature name="OSHealthFitness">
         <param name="android-package" value="com.outsystems.plugins.healthfitness.OSHealthFitness"/>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.13@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.18@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -27,6 +27,18 @@ dependencies{
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
     implementation("com.github.outsystems:oshealthfitness-android:1.2.0.18@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
+
+    // activity
+    implementation "androidx.activity:activity-ktx:1.8.2"
+
+    // appcompact
+    implementation "androidx.appcompat:appcompat:1.6.1"
+
+    // health connect sdk
+    implementation "androidx.health.connect:connect-client:1.1.0-alpha07"
+
+    // work manager
+    implementation "androidx.work:work-runtime-ktx:2.9.0"
     
     def roomVersion = "2.4.2"
     implementation("androidx.room:room-runtime:$roomVersion")

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -39,6 +39,11 @@ dependencies{
 
     // work manager
     implementation "androidx.work:work-runtime-ktx:2.9.0"
+
+    // compose
+    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation 'androidx.compose.material3:material3:1.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
     
     def roomVersion = "2.4.2"
     implementation("androidx.room:room-runtime:$roomVersion")

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.18@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.13@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
     
     def roomVersion = "2.4.2"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Implements `androidCopyPreferencesPermissions.js` hook that does the following:
    - Adds the health connect permissions (e.g. `android.permission.health.READ_HEART_RATE`) to both the `AndroidManfiest.xml` file and the `health_permissions.xml` file.
    - Adds the background job permissions (e.g. `android.permission.POST_NOTIFICATIONS`) to the `AndroidManifest.xml` file.
    - Copies the notification title and content for the foreground notification to be shown when the app is processing a background job.
- It also adds the `PermissionsRationaleActivity` to the `AndroidManifest.xml` file, tying the `health_permissions.xml` file to it.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3142

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=8a73f6d9ea8fd632c0adba280cc1252e1418f361

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
