### PR TITLE
RMET-3190 H&F Plugin - Use exact alarms for background jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2024-03-14
+- Implemented the usage of exact alarms for background jobs  (https://outsystemsrd.atlassian.net/browse/RMET-3190).
+
 ## 2024-02-28
 - Implemented `Open Health Connect App`  (https://outsystemsrd.atlassian.net/browse/RMET-3158).
 

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -275,6 +275,7 @@ function addBackgroundJobPermissionsToManifest(configParser, projectRoot, parser
         addEntryToManifest(manifestXmlDoc, 'android.permission.FOREGROUND_SERVICE')
         addEntryToManifest(manifestXmlDoc, 'android.permission.FOREGROUND_SERVICE_HEALTH')
         addEntryToManifest(manifestXmlDoc, 'android.permission.HIGH_SAMPLING_RATE_SENSORS')
+        addEntryToManifest(manifestXmlDoc, 'android.permission.SCHEDULE_EXACT_ALARM')
 
         // serialize the updated XML document back to string
         const serializer = new XMLSerializer();

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -24,7 +24,7 @@ dependencies{
     implementation 'com.google.code.findbugs:jsr305:1.3.9'
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
-    implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
+    implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
     implementation("com.github.outsystems:oshealthfitness-android:1.2.0.20@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.21@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.22@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     // activity

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.20@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.21@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     // activity

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -129,6 +129,7 @@ class OSHealthFitness : CordovaImplementation() {
         return true
     }
 
+    // onResume is called when returning from the SCHEDULE_EXACT_ALARM permission screen
     override fun onResume(multitasking: Boolean) {
         if (requestingExactAlarmPermission) {
             requestingExactAlarmPermission = false

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -218,6 +218,7 @@ class OSHealthFitness : CordovaImplementation() {
         val parameters = gson.fromJson(args.getString(0), HealthAdvancedQueryParameters::class.java)
         healthConnectViewModel.advancedQuery(
             parameters,
+            getContext(),
             { response ->
                 val pluginResponseJson = gson.toJson(response)
                 sendPluginResult(pluginResponseJson)

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -32,7 +32,7 @@ class OSHealthFitness : CordovaImplementation() {
     private lateinit var healthConnectRepository: HealthConnectRepository
     private lateinit var healthConnectDataManager: HealthConnectDataManager
     private lateinit var healthConnectHelper: HealthConnectHelper
-    private lateinit var workManagerHelper: WorkManagerHelperInterface
+    private lateinit var alarmManagerHelper: AlarmManagerHelper
     private lateinit var backgroundParameters: BackgroundJobParameters
 
     private lateinit var alarmManager: AlarmManager
@@ -56,9 +56,9 @@ class OSHealthFitness : CordovaImplementation() {
         healthConnectDataManager = HealthConnectDataManager(database)
         healthConnectRepository = HealthConnectRepository(healthConnectDataManager)
         healthConnectHelper = HealthConnectHelper()
-        workManagerHelper = WorkManagerHelper()
+        alarmManagerHelper = AlarmManagerHelper()
         healthConnectViewModel =
-            HealthConnectViewModel(healthConnectRepository, healthConnectHelper, workManagerHelper)
+            HealthConnectViewModel(healthConnectRepository, healthConnectHelper, alarmManagerHelper)
         alarmManager = getContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
         // get foreground notification title and description from resources (strings.xml)

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt
@@ -41,6 +41,12 @@ class OSHealthFitness : CordovaImplementation() {
     // returning from the SCHEDULE_EXACT_ALARM permission screen
     private var requestingExactAlarmPermission = false
 
+    // variables to hold foreground notification title and description
+    // these values are defined in build time so we only need to read
+    // them once on the initialize method
+    private lateinit var foregroundNotificationTitle: String
+    private lateinit var foregroundNotificationDescription: String
+
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
         super.initialize(cordova, webView)
         val manager = HealthFitnessManager(cordova.context, cordova.activity)
@@ -54,6 +60,23 @@ class OSHealthFitness : CordovaImplementation() {
         healthConnectViewModel =
             HealthConnectViewModel(healthConnectRepository, healthConnectHelper, workManagerHelper)
         alarmManager = getContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        // get foreground notification title and description from resources (strings.xml)
+        foregroundNotificationTitle = getContext().resources.getString(
+            getActivity().resources.getIdentifier(
+                "background_notification_title",
+                "string",
+                getActivity().packageName
+            )
+        )
+        foregroundNotificationDescription = getContext().resources.getString(
+            getActivity().resources.getIdentifier(
+                "background_notification_description",
+                "string",
+                getActivity().packageName
+            )
+        )
+
     }
 
     override fun execute(
@@ -307,6 +330,8 @@ class OSHealthFitness : CordovaImplementation() {
     private fun setBackgroundJobWithParameters(parameters: BackgroundJobParameters) {
         healthConnectViewModel.setBackgroundJob(
             parameters,
+            foregroundNotificationTitle,
+            foregroundNotificationDescription,
             getContext(),
             {
                 sendPluginResult("success", null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR adds the code to request the `SCHEDULE_EXACT_ALARM` permission that is necessary when working with exact alarms, for Android >= 14.
- It also adds this permission to the app's manifest, adding it in `hooks/androidCopyPreferencesPermissions.js`.
- It also updates the dependency to the` OSHealthFitnessLib-Android` library, also applying some minor updates to the calls to `setBackgroundJob`, `deleteBackgroundJob`, and `advancedQuery`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3190

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- All unit tests passing.

- MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=a4d36f7296e71b7cf49c9d289f379072999eb8d9

- Tested in Android 14 (Pixel 7), Android 13 (Samsung A51), and Android 12 (Pixel 3XL)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
