### PR TITLE
RMET-3246 H&F Plugin - Fix hook for ODC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2024-03-22
+- Fixed hook for ODC  (https://outsystemsrd.atlassian.net/browse/RMET-3191).
+
 ## 2024-03-18
-- Implemented the usage of the Activity Transition Recognition API for background jobs  (https://outsystemsrd.atlassian.net/browse/RMET-3191).
+- Implemented the usage of the Activity Transition Recognition API for background jobs  (https://outsystemsrd.atlassian.net/browse/RMET-3246).
 
 ## 2024-03-14
 - Implemented the usage of exact alarms for background jobs  (https://outsystemsrd.atlassian.net/browse/RMET-3190).

--- a/hooks/androidCopyPrivacyUrlEnv.js
+++ b/hooks/androidCopyPrivacyUrlEnv.js
@@ -11,9 +11,11 @@ module.exports = async function (context) {
     const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     const platformPath = path.join(projectRoot, `platforms/android/app/src/main/assets/www/${fileNamePrivacyPolicy}`);
 
-    if (fileExists(platformPath)) {
+    if (fileExists(platformPath) || policyFileExists()) {
         const configXML = path.join(projectRoot, 'config.xml');
         const configParser = new ConfigParser(configXML);
+
+        console.log("file exists");
         
         setPrivacyPolicyUrl(configParser, projectRoot);
     } else {
@@ -26,6 +28,10 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
     const applicationNameUrl = configParser.getPreference('DefaultApplicationURL', 'android');
     
     if (hostname && applicationNameUrl) {
+
+
+        console.log("inside if");
+
         const url = `https://${hostname}/${applicationNameUrl}/${fileNamePrivacyPolicy}`;
         const stringsPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
         const stringsFile = fs.readFileSync(stringsPath).toString();
@@ -41,5 +47,25 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
         fs.writeFileSync(stringsPath, resultXmlStrings);
     } else {
         throw new Error("Error getting the environment variables.");
+    }
+}
+
+function policyFileExists() {
+    const directoryPath = 'platforms/android/app/src/main/assets/www';
+    const searchString = 'HealthConnect_PrivacyPolicy';
+
+    console.log("about to readdirSync");
+
+    try {
+        const files = fs.readdirSync(directoryPath);
+        const matchingFiles = files.filter(fileName => fileName.includes(searchString));
+    
+        console.log("about to return policyFileExists");
+
+        // return true if there are matching files, false otherwise
+        return matchingFiles.length > 0;
+    } catch (error) {
+        console.error('An error occurred:', error);
+        return false;
     }
 }

--- a/hooks/androidCopyPrivacyUrlEnv.js
+++ b/hooks/androidCopyPrivacyUrlEnv.js
@@ -14,8 +14,6 @@ module.exports = async function (context) {
     if (fileExists(platformPath) || policyFileExists()) {
         const configXML = path.join(projectRoot, 'config.xml');
         const configParser = new ConfigParser(configXML);
-
-        console.log("file exists");
         
         setPrivacyPolicyUrl(configParser, projectRoot);
     } else {
@@ -28,10 +26,6 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
     const applicationNameUrl = configParser.getPreference('DefaultApplicationURL', 'android');
     
     if (hostname && applicationNameUrl) {
-
-
-        console.log("inside if");
-
         const url = `https://${hostname}/${applicationNameUrl}/${fileNamePrivacyPolicy}`;
         const stringsPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
         const stringsFile = fs.readFileSync(stringsPath).toString();
@@ -53,15 +47,10 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
 function policyFileExists() {
     const directoryPath = 'platforms/android/app/src/main/assets/www';
     const searchString = 'HealthConnect_PrivacyPolicy';
-
-    console.log("about to readdirSync");
-
     try {
         const files = fs.readdirSync(directoryPath);
         const matchingFiles = files.filter(fileName => fileName.includes(searchString));
-    
-        console.log("about to return policyFileExists");
-
+        
         // return true if there are matching files, false otherwise
         return matchingFiles.length > 0;
     } catch (error) {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -26,7 +26,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.26@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:1.2.0.27@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     // activity


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR adds an alternative way of checking if the privacy policy file exists.
- Because in ODC, resources have their original name changed with a suffix appended, we need to check for files which names contain the original file name (`HealthConnect_PrivacyPolicy`).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3246

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with ODC MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=a48cd6a91fe3ad31a589be442e7b3b7be2b9db46

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
