### PR TITLE
RMET-3134 H&F Plugin - Fix privacy policy opening for Android <= 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+ ## 2024-04-05
+- Fix privacy policy opening for Android <= 13 (https://outsystemsrd.atlassian.net/browse/RMET-3134).
+
  ## 2024-04-04
 - Update GSON version to remove vulnerability (https://outsystemsrd.atlassian.net/browse/RMET-3134).
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,6 +39,16 @@
           android:name="health_permissions"
           android:resource="@array/health_permissions" />
       </activity>
+      <activity-alias
+            android:name=".ViewPermissionUsageActivity"
+            android:exported="true"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE"
+            android:targetActivity=".PermissionsRationaleActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
    </config-file>
 
     <!-- HealthFitness Plugin -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,29 +27,7 @@
       <string name="background_notification_description"></string>
    </config-file>
 
-   <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <activity
-        android:name=".PermissionsRationaleActivity"
-        android:theme="@style/Theme.AppCompat"
-        android:exported="true">
-        <intent-filter>
-          <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
-        </intent-filter>
-        <meta-data
-          android:name="health_permissions"
-          android:resource="@array/health_permissions" />
-      </activity>
-      <activity-alias
-            android:name=".ViewPermissionUsageActivity"
-            android:exported="true"
-            android:permission="android.permission.START_VIEW_PERMISSION_USAGE"
-            android:targetActivity=".PermissionsRationaleActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
-                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
-            </intent-filter>
-        </activity-alias>
-   </config-file>
+
 
     <!-- HealthFitness Plugin -->
     <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,8 +27,6 @@
       <string name="background_notification_description"></string>
    </config-file>
 
-
-
     <!-- HealthFitness Plugin -->
     <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Removes the `PermissionsRationaleActivity` from the `plugin.xml`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

- This was breaking the feature of opening the privacy policy page for Android <= 13.
- The library already adds this, so the plugin doesn't need to.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested on Android 14 (Pixel 7), Android 13 (Samsung A51), Android 12 (Pixel 3XL)

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=79a1545de83459f2d94954e590e8e958fd7b2849

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
