### PR TITLE
RMET-3363 - Add OxygenSaturation Permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2024-05-09
+- Implemented support for `OxygenSaturation` variable when using advanced query or getHealthData (https://outsystemsrd.atlassian.net/browse/RMET-3363).
+
 ### 2024-04-24
 
 - Chore: Update cordova hooks with new OutSystems specific errors. (https://outsystemsrd.atlassian.net/browse/RMET-3388).

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -92,6 +92,13 @@ let permissions = {
         writePermission: "android.permission.health.WRITE_DISTANCE",
         configValue: undefined,
         wasSet: false
+    },
+    OxygenSaturation: {
+        variableName: "OxygenSaturation",
+        readPermission: "android.permission.health.READ_OXYGEN_SATURATION",
+        writePermission: "android.permission.health.WRITE_OXYGEN_SATURATION",
+        configValue: undefined,
+        wasSet: false
     }
 }
 
@@ -114,7 +121,7 @@ let groupPermissions = {
         variableName: "HealthVariables",
         configValue: undefined,
         wasSet: false,
-        groupVariables: ["HeartRate", "Sleep", "BloodPressure", "BloodGlucose"]
+        groupVariables: ["HeartRate", "Sleep", "BloodPressure", "BloodGlucose", "OxygenSaturation"]
     },
     ProfileVariables: {
         variableName: "ProfileVariables",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR adds support for the `OxygenSaturation` variable by adding the read and write permissions to the android hooks.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3363
https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4081516683/LLD+-+Adding+support+for+Oxygen+Saturation

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested in Android 14.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
