### PR TITLE
RMET-3406 ::: Android ::: Add More Verifications for Privacy Policy File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changes documented here do not include those from the original repository.
 
 ## [2.1.0]
 
+- Fix: Add format verification for Android's Privacy Policy file (https://outsystemsrd.atlassian.net/browse/RMET-3406).
 - Feat: Implemented support for `OxygenSaturation` variable when using requestPermissions, advancedQuery, getHealthData, and background jobs (https://outsystemsrd.atlassian.net/browse/RMET-3363).
 
 ## [2.0.1]

--- a/hooks/androidCopyPrivacyUrlEnv.js
+++ b/hooks/androidCopyPrivacyUrlEnv.js
@@ -5,13 +5,16 @@ const path = require('path');
 const { ConfigParser } = require('cordova-common');
 const et = require('elementtree');
 const { fileExists } = require('./utils');
+
 let fileNamePrivacyPolicy = "HealthConnect_PrivacyPolicy.txt";
+let mainFolder = "platforms/android/app/src/main/";
 
 module.exports = async function (context) {
     const projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
-    const platformPath = path.join(projectRoot, `platforms/android/app/src/main/assets/www/${fileNamePrivacyPolicy}`);
+    const directoryPath = path.join(projectRoot, mainFolder);
+    const platformPath = path.join(directoryPath, `assets/www/${fileNamePrivacyPolicy}`);
 
-    if (fileExists(platformPath) || policyFileExists()) {
+    if (fileExists(platformPath) || policyFileExists(directoryPath)) {
         const configXML = path.join(projectRoot, 'config.xml');
         const configParser = new ConfigParser(configXML);
         
@@ -27,7 +30,7 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
     
     if (hostname && applicationNameUrl) {
         const url = `https://${hostname}/${applicationNameUrl}/${fileNamePrivacyPolicy}`;
-        const stringsPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
+        const stringsPath = path.join(projectRoot, mainFolder, 'res/values/strings.xml');
         const stringsFile = fs.readFileSync(stringsPath).toString();
         const etreeStrings = et.parse(stringsFile);
     
@@ -43,12 +46,12 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
     }
 }
 
-function policyFileExists() {
-    const directoryPath = 'platforms/android/app/src/main/assets/www';
-    const searchString = 'HealthConnect_PrivacyPolicy';
+function policyFileExists(platformPath) {
+    const directoryPath = path.join(platformPath, 'assets/www');
+    //const searchString = 'HealthConnect_PrivacyPolicy';
     try {
         const files = fs.readdirSync(directoryPath);
-        const matchingFiles = files.filter(fileName => fileName.includes(searchString));
+        const matchingFiles = files.filter(fileName => fileName.includes(fileNamePrivacyPolicy));
         
         // return true if there are matching files, false otherwise
         return matchingFiles.length > 0;

--- a/hooks/androidCopyPrivacyUrlEnv.js
+++ b/hooks/androidCopyPrivacyUrlEnv.js
@@ -48,10 +48,12 @@ function setPrivacyPolicyUrl(configParser, projectRoot) {
 
 function policyFileExists(platformPath) {
     const directoryPath = path.join(platformPath, 'assets/www');
-    //const searchString = 'HealthConnect_PrivacyPolicy';
+    // splits the file in name & format.
+    const searchStrings = fileNamePrivacyPolicy.split('.');
+
     try {
         const files = fs.readdirSync(directoryPath);
-        const matchingFiles = files.filter(fileName => fileName.includes(fileNamePrivacyPolicy));
+        const matchingFiles = files.filter(fileName => fileName.startsWith(searchStrings[0]) && fileName.endsWith(searchStrings[1]));
         
         // return true if there are matching files, false otherwise
         return matchingFiles.length > 0;


### PR DESCRIPTION
## Description
- Include the file extension on the `policyFileExists` method. Since ODC adds some text between the file name and extension, add some log to validate that the file starts with the file name and ends with the 'txt' format.
- Remove some redundant code.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3406

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Manual testing was done to validate the fix.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows the code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
