### PR TITLE
Prepare Release of `2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## [2.2.0]
 
 ### Features
 
+- (ios): Implement support for `Body Temperature` health variable (https://outsystemsrd.atlassian.net/browse/RMET-3672).
 - (android): Implement support for `Body Temperature` health variable (https://outsystemsrd.atlassian.net/browse/RMET-3673).
 
 ## [2.1.2]

--- a/hooks/androidCopyPreferencesPermissions.js
+++ b/hooks/androidCopyPreferencesPermissions.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { ConfigParser } = require('cordova-common');
-const { DOMParser, XMLSerializer } = require('xmldom');
+const { DOMParser, XMLSerializer } = require('@xmldom/xmldom');
 
 const READ = "Read"
 const WRITE = "Write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.healthfitness",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Health & Fitness cordova plugin for OutSystems applications.",
   "keywords": [
     "ecosystem:cordova",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "engines": [],
   "dependencies": {
-    "xmldom": "^0.6.0"
+    "@xmldom/xmldom": "^0.9.0"
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.healthfitness" version="2.1.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.healthfitness" version="2.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>HealthFitness</name>
   <description>Health &amp; Fitness cordova plugin for OutSystems applications.</description>
   <author>OutSystems Inc</author>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:2.1.2@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:2.2.0@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     // activity


### PR DESCRIPTION
It includes an update to the `xmldom` dependency, fixing an Snyk vulnerability found with version `0.6.0`.