### PR TITLE
RMET-3831 :: Revamp + Fix of Advanced Query logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [2.3.0]
+
+### Fixes
+
+- (android): Fixes advanced query for custom aggregation metrics (https://outsystemsrd.atlassian.net/browse/RMET-3831)
+
 ## [2.2.1]
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.healthfitness",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Health & Fitness cordova plugin for OutSystems applications.",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.healthfitness" version="2.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.healthfitness" version="2.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>HealthFitness</name>
   <description>Health &amp; Fitness cordova plugin for OutSystems applications.</description>
   <author>OutSystems Inc</author>
@@ -29,6 +29,8 @@
 
     <!-- HealthFitness Plugin -->
     <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitness.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
+    <source-file src="src/android/com/outsystems/plugins/healthfitness/OSHealthFitnessWarning.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
+    <source-file src="src/android/com/outsystems/plugins/healthfitness/TimeUnitSerializer.kt" target-dir="app/src/main/kotlin/com/outsystems/plugins/healthfitness"/>
 
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     <framework src="org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.3" />

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -25,7 +25,7 @@ dependencies{
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:oshealthfitness-android:2.2.1@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:2.3.0@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     // activity

--- a/src/android/com/outsystems/plugins/healthfitness/OSHealthFitnessWarning.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/OSHealthFitnessWarning.kt
@@ -1,0 +1,6 @@
+package com.outsystems.plugins.healthfitness
+
+enum class OSHealthFitnessWarning(val code: Int, val message: String) {
+    DEPRECATED_TIME_UNIT(405,
+        "The TimeUnit parameters of type MILLISECONDS or SECONDS are deprecated on Android. By default, TimeUnit will be set to MINUTE.");
+}

--- a/src/android/com/outsystems/plugins/healthfitness/TimeUnitSerializer.kt
+++ b/src/android/com/outsystems/plugins/healthfitness/TimeUnitSerializer.kt
@@ -1,0 +1,44 @@
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import com.outsystems.plugins.healthfitness.data.HealthEnumTimeUnit
+import java.lang.reflect.Type
+
+class TimeUnitSerializer(
+    private val onDeprecatedFound: () -> Unit
+) : JsonSerializer<HealthEnumTimeUnit>, JsonDeserializer<HealthEnumTimeUnit> {
+
+    // How to write Status to JSON
+    override fun serialize(
+        src: HealthEnumTimeUnit?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        return JsonPrimitive(src?.name)
+    }
+
+    // How to read Status from JSON
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): HealthEnumTimeUnit {
+        return when (val value = json?.asString) {
+            "SECONDS", "MILLISECONDS" -> {
+                onDeprecatedFound()
+                HealthEnumTimeUnit.MINUTE
+            }
+            "MINUTE" -> HealthEnumTimeUnit.MINUTE
+            "HOUR" -> HealthEnumTimeUnit.HOUR
+            "DAY" -> HealthEnumTimeUnit.DAY
+            "WEEK" -> HealthEnumTimeUnit.WEEK
+            "MONTH" -> HealthEnumTimeUnit.MONTH
+            "YEAR" -> HealthEnumTimeUnit.YEAR
+            else -> throw JsonParseException("Unknown time unit: $value")
+        }
+    }
+}


### PR DESCRIPTION

## Description
This PR:
- updates the library's version to include the changes made to advance query
- changes the plugin bridge to extend `CordovaPlugin` instead of CordovaImplementation
- removes the logic related with MILLISECONDS and SECONDS to the bridge: the library was already converting them into 1 minute intervals, only because of backwards compatibility with the OutSystems wrapper. As such, the Android library sends a warning stating this data manipulation and once iOS is updated, this can be removed to only the OS Wrapper

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3831

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
