### PR TITLE
RMET-4025 - Update hook to avoid duplicates in XML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Features
+- (android) Updates hooks to avoid duplicates in XML files (https://outsystemsrd.atlassian.net/browse/RMET-4025).
+
 ## [2.3.2]
 
 ### Features


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates hook to avoid duplicates in `strings.xml` and `AndroidManifest.xml`
- If the hook runs more than once in a build for some reason, the values it adds would be duplicated, which would cause the Android build to fail if values were duplicated in `strings.xml`. If permissions are duplicated in the AndroidManifest.xml file, the build wouldn't fail, but we should still avoid duplicating them.
- This happens when building apps with MOCA instead of MABS

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-4025

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested MABS 11.1 builds with MOCA instead of MABS.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
