### PR TITLE
fix: convert LocalDateTime to Instant in groupByDuration to avoid DST crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [3.0.2]
+
+### Fixes
+
+- (android) convert LocalDateTime to Instant in `groupByDuration` to avoid DST crash (https://outsystemsrd.atlassian.net/browse/RMET-5
+
 ## [3.0.1]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changes documented here do not include those from the original repository.
 
 ### Fixes
 
-- (android) convert LocalDateTime to Instant in `groupByDuration` to avoid DST crash (https://outsystemsrd.atlassian.net/browse/RMET-5
+- (android) convert LocalDateTime to Instant in `groupByDuration` to avoid DST crash (https://outsystemsrd.atlassian.net/browse/RMET-5134)
 
 ## [3.0.1]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.healthfitness",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Health & Fitness cordova plugin for OutSystems applications.",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.healthfitness" version="3.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.healthfitness" version="3.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>HealthFitness</name>
   <description>Health &amp; Fitness cordova plugin for OutSystems applications.</description>
   <author>OutSystems Inc</author>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -22,7 +22,7 @@ dependencies{
 
     implementation 'com.google.code.findbugs:jsr305:1.3.9'
 
-    implementation("com.github.outsystems:oshealthfitness-android:3.0.0@aar")
+    implementation("com.github.outsystems:oshealthfitness-android:3.0.1@aar")
 
     // activity
     implementation "androidx.activity:activity-ktx:1.8.2"


### PR DESCRIPTION
Health Connect SDK throws IllegalArgumentException ("start time must be before end time") when aggregating data by duration over a DST transition, because LocalDateTime has no timezone info and the SDK creates buckets with
inconsistent offsets. Fix by converting start/end dates to Instant (UTC) before passing to TimeRangeFilter.between().

This PR addresses the issue https://outsystemsrd.atlassian.net/browse/RMET-5134