### PR TITLE
ci: Release and Changelog Automation

### DIFF
--- a/.github/scripts/compute_release.cjs
+++ b/.github/scripts/compute_release.cjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/*
+ * Computes the next version for a PR and updates package.json, plugin.xml,
+ * and CHANGELOG.md inside PR_DIR accordingly.
+ *
+ * This script is always executed from the default-branch clone (never from
+ * PR-controlled code). It reads PR metadata via environment variables (no
+ * shell interpolation) and writes outputs to the file pointed to by
+ * $GITHUB_OUTPUT.
+ *
+ * Required env vars:
+ *   PR_TITLE        PR title
+ *   PR_BODY         PR body (may be empty)
+ *   PR_NUMBER       PR number
+ *   COMMIT_FOOTERS  Concatenated commit messages from the PR
+ *   MAIN_DIR        Path to the default-branch clone (read-only baseline)
+ *   PR_DIR          Path to the PR head clone (files are rewritten here)
+ *
+ * Optional:
+ *   GITHUB_OUTPUT   Path to GH Actions step outputs file; falls back to stdout
+ *
+ * Outputs (written to $GITHUB_OUTPUT or stdout):
+ *   bump=major|minor|patch|none
+ *   version=X.Y.Z   (omitted when bump=none)
+ *   changed=true|false
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PR_TITLE = process.env.PR_TITLE || '';
+const PR_BODY = process.env.PR_BODY || '';
+const PR_NUMBER = process.env.PR_NUMBER || '';
+const COMMIT_FOOTERS = process.env.COMMIT_FOOTERS || '';
+const MAIN_DIR = process.env.MAIN_DIR;
+const PR_DIR = process.env.PR_DIR;
+const OUTPUT_PATH = process.env.GITHUB_OUTPUT;
+
+if (!MAIN_DIR || !PR_DIR) {
+  console.error('MAIN_DIR and PR_DIR env vars are required');
+  process.exit(1);
+}
+
+function writeOutput(key, value) {
+  const line = `${key}=${value}\n`;
+  if (OUTPUT_PATH) {
+    fs.appendFileSync(OUTPUT_PATH, line);
+  } else {
+    process.stdout.write(`OUTPUT ${line}`);
+  }
+}
+
+const TITLE_RE = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+const BREAKING_RE = /^BREAKING CHANGE:/m;
+
+function parseTitle(title) {
+  const m = title.match(TITLE_RE);
+  if (!m) return null;
+  return {
+    type: m[1],
+    scope: m[2] || null,
+    breaking: Boolean(m[3]),
+    description: m[4],
+  };
+}
+
+function hasBreakingChange(parsed) {
+  if (parsed.breaking) return true;
+  if (BREAKING_RE.test(PR_BODY)) return true;
+  if (BREAKING_RE.test(COMMIT_FOOTERS)) return true;
+  return false;
+}
+
+function computeBump(parsed) {
+  if (hasBreakingChange(parsed)) return 'major';
+  if (parsed.type === 'feat') return 'minor';
+  if (parsed.type === 'fix' || parsed.type === 'chore' || parsed.type === 'refactor') return 'patch';
+  return 'none';
+}
+
+function bumpVersion(version, bump) {
+  const [major, minor, patch] = version.split('.').map(Number);
+  if (bump === 'major') return `${major + 1}.0.0`;
+  if (bump === 'minor') return `${major}.${minor + 1}.0`;
+  if (bump === 'patch') return `${major}.${minor}.${patch + 1}`;
+  return version;
+}
+
+function subsectionFor(bump, type) {
+  if (bump === 'major') return '### BREAKING CHANGES';
+  if (type === 'feat') return '### Features';
+  if (type === 'fix') return '### Fixes';
+  return '### Chores';
+}
+
+// Detects whether the CHANGELOG uses "## [X.Y.Z]" (bracketed) or "## X.Y.Z" (plain).
+function detectChangelogFormat(content) {
+  const m = content.match(/^##\s+(\[?\d+\.\d+\.\d+\]?)/m);
+  if (m && m[1].startsWith('[')) return 'bracketed';
+  return 'plain';
+}
+
+// Handles: "## X.Y.Z", "## [X.Y.Z]", and "## [X.Y.Z] - YYYY-MM-DD"
+function latestChangelogVersion(content) {
+  const m = content.match(/^##\s+\[?(\d+\.\d+\.\d+)\]?(?:\s+-\s+\S+)?\s*$/m);
+  return m ? m[1] : null;
+}
+
+function readFileOrEmpty(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function readMainPackageVersion() {
+  const p = path.join(MAIN_DIR, 'package.json');
+  try {
+    const json = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return json.version || null;
+  } catch {
+    return null;
+  }
+}
+
+function buildChangelogEntry(version, bump, parsed, format) {
+  const sub = subsectionFor(bump, parsed.type);
+  const prRef = PR_NUMBER ? ` (#${PR_NUMBER})` : '';
+  const versionTag = format === 'bracketed' ? `[${version}]` : version;
+  return `## ${versionTag}\n\n${sub}\n\n- ${PR_TITLE}${prRef}\n\n`;
+}
+
+function rebuildChangelog(mainChangelog, newEntry) {
+  if (!newEntry) return mainChangelog;
+  const firstSection = mainChangelog.match(/^##\s+/m);
+  if (firstSection) {
+    const idx = mainChangelog.indexOf(firstSection[0]);
+    return mainChangelog.slice(0, idx) + newEntry + mainChangelog.slice(idx);
+  }
+  const header = mainChangelog.trim().length > 0
+    ? mainChangelog.trimEnd() + '\n\n'
+    : '# Changelog\n\n';
+  return header + newEntry;
+}
+
+function rewritePackageVersion(raw, version) {
+  const re = /("version"\s*:\s*")(\d+\.\d+\.\d+)(")/;
+  if (!re.test(raw)) {
+    throw new Error('Could not locate "version" field in package.json');
+  }
+  return raw.replace(re, `$1${version}$3`);
+}
+
+function rewritePluginXmlVersion(raw, version) {
+  // Match the version attribute on the opening <plugin> tag only.
+  // [^>]*? ensures we don't cross past the closing > of that tag.
+  const re = /(<plugin\b[^>]*?\bversion=")(\d+\.\d+\.\d+)(")/;
+  if (!re.test(raw)) {
+    throw new Error('Could not locate version attribute on <plugin> element in plugin.xml');
+  }
+  return raw.replace(re, `$1${version}$3`);
+}
+
+async function main() {
+  const parsed = parseTitle(PR_TITLE);
+  if (!parsed) {
+    console.error(`PR title does not match conventional commits format: "${PR_TITLE}"`);
+    process.exit(1);
+  }
+
+  const bump = computeBump(parsed);
+  const mainChangelogPath = path.join(MAIN_DIR, 'CHANGELOG.md');
+  const mainChangelog = readFileOrEmpty(mainChangelogPath);
+  const format = detectChangelogFormat(mainChangelog);
+  const lastLogged = latestChangelogVersion(mainChangelog);
+  const mainPkgVersion = readMainPackageVersion();
+  const baseline = lastLogged || mainPkgVersion;
+
+  let targetVersion;
+  let newChangelog;
+
+  if (bump === 'none') {
+    targetVersion = baseline;
+    newChangelog = mainChangelog;
+    console.log(`PR type "${parsed.type}" does not trigger a release.`);
+  } else if (!lastLogged) {
+    targetVersion = '1.0.0';
+    newChangelog = rebuildChangelog(
+      mainChangelog,
+      buildChangelogEntry(targetVersion, bump, parsed, format),
+    );
+    console.log('First release detected — defaulting to 1.0.0.');
+  } else {
+    targetVersion = bumpVersion(baseline, bump);
+    newChangelog = rebuildChangelog(
+      mainChangelog,
+      buildChangelogEntry(targetVersion, bump, parsed, format),
+    );
+  }
+
+  console.log(`Baseline version: ${baseline || '<none>'}`);
+  console.log(`Bump: ${bump}`);
+  console.log(`Target version: ${targetVersion || '<unchanged>'}`);
+  console.log(`CHANGELOG format: ${format}`);
+
+  if (!targetVersion) {
+    console.log('No baseline version available and no release triggered — nothing to do.');
+    writeOutput('bump', 'none');
+    writeOutput('changed', 'false');
+    return;
+  }
+
+  const pkgPath = path.join(PR_DIR, 'package.json');
+  const xmlPath = path.join(PR_DIR, 'plugin.xml');
+  const changelogPath = path.join(PR_DIR, 'CHANGELOG.md');
+
+  const pkgRaw = fs.readFileSync(pkgPath, 'utf8');
+  const xmlRaw = fs.readFileSync(xmlPath, 'utf8');
+  const currentChangelog = readFileOrEmpty(changelogPath);
+
+  const newPkgRaw = rewritePackageVersion(pkgRaw, targetVersion);
+  const newXmlRaw = rewritePluginXmlVersion(xmlRaw, targetVersion);
+
+  const changed =
+    newPkgRaw !== pkgRaw ||
+    newXmlRaw !== xmlRaw ||
+    newChangelog !== currentChangelog;
+
+  if (!changed) {
+    console.log('No changes needed — files already at target state.');
+    writeOutput('bump', bump);
+    if (bump !== 'none') writeOutput('version', targetVersion);
+    writeOutput('changed', 'false');
+    return;
+  }
+
+  fs.writeFileSync(pkgPath, newPkgRaw);
+  fs.writeFileSync(xmlPath, newXmlRaw);
+  fs.writeFileSync(changelogPath, newChangelog);
+
+  console.log(`Updated package.json, plugin.xml, CHANGELOG.md to ${targetVersion}`);
+  writeOutput('bump', bump);
+  if (bump !== 'none') writeOutput('version', targetVersion);
+  writeOutput('changed', 'true');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/bump_version_in_pr.yml
+++ b/.github/workflows/bump_version_in_pr.yml
@@ -1,0 +1,173 @@
+name: Bump version in PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to bump'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: bump-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    if: github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve PR metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER_INPUT: ${{ github.event.pull_request.number || inputs.pr }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER_INPUT}" > /tmp/pr.json
+          head_ref=$(jq -r '.head.ref' /tmp/pr.json)
+          head_repo=$(jq -r '.head.repo.full_name // ""' /tmp/pr.json)
+          base_ref=$(jq -r '.base.ref' /tmp/pr.json)
+          title=$(jq -r '.title' /tmp/pr.json)
+          body=$(jq -r '.body // ""' /tmp/pr.json)
+          {
+            echo "PR_NUMBER=$PR_NUMBER_INPUT"
+            echo "PR_HEAD_REF=$head_ref"
+            echo "PR_HEAD_REPO=$head_repo"
+            echo "PR_BASE_REF=$base_ref"
+            echo "PR_TITLE<<EOF_TITLE"
+            echo "$title"
+            echo "EOF_TITLE"
+            echo "PR_BODY<<EOF_BODY"
+            echo "$body"
+            echo "EOF_BODY"
+          } >> "$GITHUB_ENV"
+          echo "Resolved PR #$PR_NUMBER_INPUT: head=$head_repo@$head_ref base=$base_ref"
+
+      - name: Skip if PR does not target main
+        id: gate_base
+        run: |
+          set -euo pipefail
+          if [ "$PR_BASE_REF" != "main" ]; then
+            echo "PR targets $PR_BASE_REF (not main) — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if PR is from a fork
+        if: steps.gate_base.outputs.skip != 'true'
+        id: gate_fork
+        run: |
+          set -euo pipefail
+          if [ "$PR_HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+            echo "PR is from a fork ($PR_HEAD_REPO) — skipping (cannot push to fork branches)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main (trusted script source)
+        if: steps.gate_base.outputs.skip != 'true' && steps.gate_fork.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+
+      - name: Checkout PR head (file write target)
+        if: steps.gate_base.outputs.skip != 'true' && steps.gate_fork.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PR_HEAD_REF }}
+          path: pr
+          token: ${{ github.token }}
+
+      - name: Fetch commit messages for breaking-change detection
+        if: steps.gate_base.outputs.skip != 'true' && steps.gate_fork.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --paginate \
+            | jq -r '.[].commit.message' > /tmp/commit-messages.txt
+          {
+            echo "COMMIT_FOOTERS<<EOF_COMMITS"
+            cat /tmp/commit-messages.txt
+            echo "EOF_COMMITS"
+          } >> "$GITHUB_ENV"
+
+      - name: Compute and apply version bump
+        if: steps.gate_base.outputs.skip != 'true' && steps.gate_fork.outputs.skip != 'true'
+        id: compute
+        env:
+          MAIN_DIR: ${{ github.workspace }}/main
+          PR_DIR: ${{ github.workspace }}/pr
+        run: node main/.github/scripts/compute_release.cjs
+
+      - name: Create verified bump commit via Git Data API
+        if: steps.compute.outputs.changed == 'true'
+        working-directory: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUMP: ${{ steps.compute.outputs.bump }}
+          VERSION: ${{ steps.compute.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ "$BUMP" = "none" ]; then
+            commit_msg="chore(release): revert version bump"
+          else
+            commit_msg="chore(release): prepare $VERSION"
+          fi
+
+          # Parent commit = current tip of the PR branch on the remote.
+          # If the remote has moved since we checked out, the final PATCH
+          # below will fail (non-fast-forward) — that's the intended behavior.
+          parent_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${PR_HEAD_REF}" --jq '.object.sha')
+          parent_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${parent_sha}" --jq '.tree.sha')
+
+          # Upload each modified file as a blob.
+          # Strip newlines from base64 output (Linux's base64 wraps at 76 cols).
+          create_blob() {
+            local path=$1
+            local b64
+            b64=$(base64 < "$path" | tr -d '\n')
+            jq -n --arg content "$b64" '{content: $content, encoding: "base64"}' \
+              | gh api -X POST "repos/${GITHUB_REPOSITORY}/git/blobs" --input - --jq '.sha'
+          }
+          pkg_blob=$(create_blob package.json)
+          xml_blob=$(create_blob plugin.xml)
+          chg_blob=$(create_blob CHANGELOG.md)
+
+          # Build a new tree based on the parent's tree, overwriting only
+          # the three files we modified.
+          tree_sha=$(jq -n \
+              --arg base "$parent_tree" \
+              --arg pkg "$pkg_blob" \
+              --arg xml "$xml_blob" \
+              --arg chg "$chg_blob" \
+              '{base_tree: $base, tree: [
+                {path: "package.json", mode: "100644", type: "blob", sha: $pkg},
+                {path: "plugin.xml",   mode: "100644", type: "blob", sha: $xml},
+                {path: "CHANGELOG.md", mode: "100644", type: "blob", sha: $chg}
+              ]}' \
+            | gh api -X POST "repos/${GITHUB_REPOSITORY}/git/trees" --input - --jq '.sha')
+
+          # Create the commit. Authored by github-actions[bot] (the installation
+          # identity behind GITHUB_TOKEN); GitHub signs it server-side so it
+          # shows as Verified.
+          commit_sha=$(jq -n \
+              --arg msg "$commit_msg" \
+              --arg tree "$tree_sha" \
+              --arg parent "$parent_sha" \
+              '{message: $msg, tree: $tree, parents: [$parent]}' \
+            | gh api -X POST "repos/${GITHUB_REPOSITORY}/git/commits" --input - --jq '.sha')
+
+          # Move the PR branch ref to the new commit. Not forced — fails if
+          # the remote ref moved since parent_sha was read.
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${PR_HEAD_REF}" \
+            -f sha="$commit_sha"
+
+          echo "Created verified commit $commit_sha on $PR_HEAD_REF"

--- a/.github/workflows/release_on_main.yml
+++ b/.github/workflows/release_on_main.yml
@@ -1,0 +1,103 @@
+name: Release on main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(jq -r '.version' package.json)
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format in package.json: $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version='${{ steps.version.outputs.version }}'
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${version}" --silent 2>/dev/null; then
+            echo "Tag $version already exists — no release needed."
+            echo "needs_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $version does not exist — proceeding to release."
+            echo "needs_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.tag.outputs.needs_release == 'true'
+        run: |
+          set -euo pipefail
+          version='${{ steps.version.outputs.version }}'
+          awk -v target="## $version" -v target_bracketed="## [$version]" '
+            $0 == target || $0 == target_bracketed || $0 ~ ("^## \\[" version "\\]( -|$)") { found=1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::error::No CHANGELOG section found for $version"
+            exit 1
+          fi
+          cat /tmp/release-notes.md
+
+      - name: Create tag and GitHub Release
+        if: steps.tag.outputs.needs_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version='${{ steps.version.outputs.version }}'
+          git tag "$version"
+          git push origin "$version"
+          gh release create "$version" \
+            --title "$version" \
+            --notes-file /tmp/release-notes.md
+
+      - name: Re-trigger bump on all open PRs targeting main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          failed_prs=()
+          mapfile -t open_prs < <(gh pr list --base main --state open --json number --jq '.[].number')
+          if [ "${#open_prs[@]}" -eq 0 ]; then
+            echo "No open PRs targeting main — nothing to dispatch."
+            exit 0
+          fi
+          for pr in "${open_prs[@]}"; do
+            echo "Dispatching bump for PR #$pr..."
+            if ! gh workflow run bump_version_in_pr.yml --ref main --field pr="$pr"; then
+              failed_prs+=("$pr")
+            fi
+          done
+          if [ "${#failed_prs[@]}" -gt 0 ]; then
+            echo "::error::Failed to dispatch bump for PRs: ${failed_prs[*]}"
+            exit 1
+          fi

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -1,0 +1,30 @@
+name: Validate PR title for Conventional Commits Format
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr-title-conventional:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title for conventional commits
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const prTitle = context.payload.pull_request.title;
+
+            // Conventional commits regex: type(scope?)!?: description
+            // Allowed types match the bump rules in compute_release.cjs.
+            const conventionalRegex = /^(feat|fix|chore|docs|style|refactor|perf|test|ci|build)(\([a-z0-9\-]+\))?!?: .+/;
+
+            if (!conventionalRegex.test(prTitle)) {
+              core.setFailed(
+                `PR title "${prTitle}" is not in conventional commit format.\n` +
+                `Example: "feat(android): add new validation function"\n` +
+                `For a breaking change, use "feat!:" or include "BREAKING CHANGE:" in the PR body or a commit footer.`
+              );
+            } else {
+              console.log(`PR title "${prTitle}" follows conventional commit format`);
+            }

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -25,8 +25,7 @@
 
 ## Checklist
 <!--- Go over all the following items and put an `x` in all the boxes that apply -->
-- [ ] Pull request title follows the format `RNMT-XXXX <title>`
 - [ ] Code follows code style of this project
-- [ ] CHANGELOG.md file is correctly updated
+- [ ] Using [conventional commits](https://www.conventionalcommits.org/)
 - [ ] Changes require an update to the documentation
 	- [ ] Documentation has been updated accordingly


### PR DESCRIPTION
## Note

One thing that is missing after merging this PR - Setting the `RELEASE_TOKEN_GITHUB` secret in the project.

## Description 

This PR is essentially a copy of the setup for https://github.com/OutSystems/cordova-outsystems-payments/pull/75 / https://github.com/OutSystems/cordova-outsystems-payments/pull/76, where we cannot push to main directly, so updates to changelog, package.json, and plugin.xml happen automatically in each PR, and then the git tag / GitHub release is created on push / merge to main.

We should aim to Squash-merge PRs always (but not 100% required)